### PR TITLE
Add functionality to display and allow the user to accept the usage tracking for Cloud Tools plugin (enabled only in IntelliJ, asked only once when plugin is first used; create a tab in Settings dialog that users can change configuration)  

### DIFF
--- a/google-login-plugin/src/META-INF/plugin.xml
+++ b/google-login-plugin/src/META-INF/plugin.xml
@@ -40,6 +40,10 @@
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">
+    <!-- Nested under "Other Settings" -->
+    <applicationConfigurable provider="com.google.gct.login.stats.GctConfigurableProvider"/>
+    <!-- Nested under specifed groupid -->
+    <!--applicationConfigurable  groupId="tools" instance="com.google.gct.login.stats.GctConfigurable" /-->
   </extensions>
 
   <extensions defaultExtensionNs="com.google.gct">

--- a/google-login-plugin/src/META-INF/plugin.xml
+++ b/google-login-plugin/src/META-INF/plugin.xml
@@ -25,6 +25,9 @@
   <idea-version since-build="107.105"/>
 
   <application-components>
+    <component>
+      <implementation-class>com.google.gct.login.stats.UsageTrackerLoader</implementation-class>
+    </component>
   </application-components>
 
   <project-components>

--- a/google-login-plugin/src/com/google/gct/login/stats/GctConfigurable.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/GctConfigurable.java
@@ -1,0 +1,89 @@
+package com.google.gct.login.stats;
+
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SearchableConfigurable;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.border.EtchedBorder;
+import javax.swing.border.TitledBorder;
+import java.awt.*;
+
+/**
+ * Created by nbashirbello on 9/29/15.
+ */
+public class GctConfigurable implements SearchableConfigurable {
+
+    // EXample CloudTestingConfigurable
+
+    private JCheckBox enableUsageTrackerBox;
+
+    public GctConfigurable() {
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+        return "google.usage.tracker";
+    }
+
+    @Nullable
+    @Override
+    public Runnable enableSearch(String option) {
+        return null;
+    }
+
+    @Nls
+    @Override
+    public String getDisplayName() {
+        return "Google Cloud Tools Plugin";
+    }
+
+    @Nullable
+    @Override
+    public String getHelpTopic() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        JPanel mainPanel = new JPanel(new BorderLayout());
+
+        // Add the Usage Tracker Box
+        JPanel usageTrackerGroup  = creatUsageTrackerComponent();
+        mainPanel.add(usageTrackerGroup, BorderLayout.NORTH);
+
+        return mainPanel;
+    }
+
+    @Override
+    public boolean isModified() {
+        return false;
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public void disposeUIResources() {
+        enableUsageTrackerBox = null;
+    }
+
+    private JPanel creatUsageTrackerComponent() {
+        enableUsageTrackerBox = new JCheckBox("Would you like to help Google improve the Cloud Tools for IntelliJ plug-in?");
+        JPanel usageTrackerGroup = new JPanel(new BorderLayout());
+        usageTrackerGroup.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED), "Usage Tracker"));
+        usageTrackerGroup.add(enableUsageTrackerBox, BorderLayout.NORTH);
+        return usageTrackerGroup;
+    }
+}

--- a/google-login-plugin/src/com/google/gct/login/stats/GctConfigurable.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/GctConfigurable.java
@@ -12,13 +12,13 @@ import javax.swing.border.TitledBorder;
 import java.awt.*;
 
 /**
- * Created by nbashirbello on 9/29/15.
+ * Implementation of {@code applicationConfigurable} extension that provides a
+ * Google Cloud Tools tab in the "Settings" dialog.
  */
 public class GctConfigurable implements SearchableConfigurable {
-
-    // EXample CloudTestingConfigurable
-
     private JCheckBox enableUsageTrackerBox;
+    private static String ENABLE_TRACKER_TEXT =
+            "Would you like to help Google improve the Cloud Tools for IntelliJ plug-in?";
 
     public GctConfigurable() {
     }
@@ -61,17 +61,17 @@ public class GctConfigurable implements SearchableConfigurable {
 
     @Override
     public boolean isModified() {
-        return false;
+        return UsageTrackerManager.getOptIn() != enableUsageTrackerBox.isSelected();
     }
 
     @Override
     public void apply() throws ConfigurationException {
-
+        UsageTrackerManager.setOptIn(enableUsageTrackerBox.isSelected());
     }
 
     @Override
     public void reset() {
-
+        enableUsageTrackerBox.setSelected(UsageTrackerManager.getOptIn());
     }
 
     @Override
@@ -80,7 +80,9 @@ public class GctConfigurable implements SearchableConfigurable {
     }
 
     private JPanel creatUsageTrackerComponent() {
-        enableUsageTrackerBox = new JCheckBox("Would you like to help Google improve the Cloud Tools for IntelliJ plug-in?");
+        enableUsageTrackerBox = new JCheckBox(ENABLE_TRACKER_TEXT);
+        enableUsageTrackerBox.setSelected(UsageTrackerManager.getOptIn());
+
         JPanel usageTrackerGroup = new JPanel(new BorderLayout());
         usageTrackerGroup.setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED), "Usage Tracker"));
         usageTrackerGroup.add(enableUsageTrackerBox, BorderLayout.NORTH);

--- a/google-login-plugin/src/com/google/gct/login/stats/GctConfigurableProvider.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/GctConfigurableProvider.java
@@ -1,0 +1,29 @@
+package com.google.gct.login.stats;
+
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurableProvider;
+import com.intellij.util.PlatformUtils;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Created by nbashirbello on 9/30/15.
+ */
+public class GctConfigurableProvider extends ConfigurableProvider {
+    @Nullable
+    @Override
+    public Configurable createConfigurable() {
+        return new GctConfigurable();
+    }
+
+    /**
+     * @return true if running platform is IntelliJ and false otherwise
+     */
+    @Override
+    public boolean canCreateConfigurable() {
+        if (PlatformUtils.isIntelliJ()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/google-login-plugin/src/com/google/gct/login/stats/GctConfigurableProvider.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/GctConfigurableProvider.java
@@ -6,7 +6,8 @@ import com.intellij.util.PlatformUtils;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Created by nbashirbello on 9/30/15.
+ * Registers an implementation of {@code applicationConfigurable} extension to provide a
+ * Google Cloud Tools tab in the "Settings" dialog if current application is IntelliJ.
  */
 public class GctConfigurableProvider extends ConfigurableProvider {
     @Nullable

--- a/google-login-plugin/src/com/google/gct/login/stats/GoogleUsageTracker.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/GoogleUsageTracker.java
@@ -69,6 +69,10 @@ public class GoogleUsageTracker implements UsageTracker {
                            @NotNull String eventAction,
                            @Nullable String eventLabel,
                            @Nullable Integer eventValue) {
+        if (!UsageTrackerManager.getOptIn()) {
+            return;
+        }
+
         if (!ApplicationManager.getApplication().isUnitTestMode()) {
             if (PlatformUtils.isIntelliJ()) {
                 ArrayList postData = Lists.newArrayList(analyticsBaseData);

--- a/google-login-plugin/src/com/google/gct/login/stats/UsageTrackerLoader.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/UsageTrackerLoader.java
@@ -1,0 +1,44 @@
+package com.google.gct.login.stats;
+
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationsConfiguration;
+import com.intellij.notification.NotificationsManager;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.ApplicationComponent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Checks to see if user has opted in/out of usage tracking for the Cloud Tools plugin.
+ * If user has not, it notifies user to opt in/out of usage tracking, otherwise it does nothing.
+ */
+public class UsageTrackerLoader implements ApplicationComponent {
+    @Override
+    public void initComponent() {
+        if (ApplicationManager.getApplication().isUnitTestMode()) {
+            return;
+        }
+
+        if (!UsageTrackerManager.isTrackingConfigured()) {
+            // Ensure that the notification manager (also an application component) is registered first;
+            // otherwise this component's initComponent() call will fire a notification event bus
+            // to show the opt-in dialog, but the notification component may not yet have been initialized
+            // and is therefore not subscribed and listening.
+            NotificationsManager.getNotificationsManager();
+            NotificationsConfiguration.getNotificationsConfiguration().register(
+                    UsageTrackerNotification.GROUP_DISPLAY_ID,
+                    NotificationDisplayType.STICKY_BALLOON);
+
+            UsageTrackerNotification.showNotification();
+        }
+    }
+
+    @Override
+    public void disposeComponent() {
+    }
+
+    @NotNull
+    @Override
+    public String getComponentName() {
+        return UsageTrackerLoader.class.getName();
+    }
+}

--- a/google-login-plugin/src/com/google/gct/login/stats/UsageTrackerManager.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/UsageTrackerManager.java
@@ -18,4 +18,11 @@ public class UsageTrackerManager {
         return PropertiesComponent.getInstance().getBoolean(USAGE_TRACKER_KEY, false);
     }
 
+    /**
+     * @return true if the user has opted in/out of usage tracking; false otherwise
+     */
+    public static boolean isTrackingConfigured() {
+        return PropertiesComponent.getInstance().getValue(USAGE_TRACKER_KEY) != null;
+    }
+
 }

--- a/google-login-plugin/src/com/google/gct/login/stats/UsageTrackerManager.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/UsageTrackerManager.java
@@ -1,0 +1,21 @@
+package com.google.gct.login.stats;
+
+import com.intellij.ide.util.PropertiesComponent;
+
+/**
+ * Stores the users choice to opt in/out of sending usage metrics via the Google Usage Tracker.
+ */
+public class UsageTrackerManager {
+    private static final String USAGE_TRACKER_KEY = "GOOGLE_CLOUD_TOOLS_USAGE_TRACKER_OPT_IN";
+
+    private UsageTrackerManager() {}
+
+    public static void setOptIn(boolean optIn) {
+        PropertiesComponent.getInstance().setValue(USAGE_TRACKER_KEY, String.valueOf(optIn));
+    }
+
+    public static boolean getOptIn() {
+        return PropertiesComponent.getInstance().getBoolean(USAGE_TRACKER_KEY, false);
+    }
+
+}

--- a/google-login-plugin/src/com/google/gct/login/stats/UsageTrackerNotification.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/UsageTrackerNotification.java
@@ -1,0 +1,58 @@
+package com.google.gct.login.stats;
+
+import com.intellij.notification.*;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.ui.popup.Balloon;
+import com.intellij.openapi.wm.IdeFrame;
+import com.intellij.openapi.wm.ex.WindowManagerEx;
+
+import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
+
+/**
+ * Creates notification to allow user to opt in/out of usage traking for Cloud Tools plugin.
+ */
+public class UsageTrackerNotification {
+    public static String GROUP_DISPLAY_ID = "Cloud Tools Plugin Usage Statistics";
+
+    private  UsageTrackerNotification () {
+    }
+
+    /**
+     * Displays the notification to allow user to opt in/out to usage tracking.
+     */
+    public static void showNotification() {
+        String title = "Help improve the Cloud Tools plugin by sending usage statistics to Google";
+        String content = "<html>Please click <a href='allow'>I agree</a> if you want to help make"
+                + " the Cloud Tools plugin better or <a href='decline'>I don't agree</a> "
+                + "otherwise. <a href='settings'>more...</a></html>";
+
+        NotificationListener listener = new NotificationListener() {
+            @Override
+            public void hyperlinkUpdate(Notification notification, HyperlinkEvent event) {
+                if (event.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                    final String description = event.getDescription();
+                    if ("allow".equals(description)) {
+                        UsageTrackerManager.setOptIn(true);
+                        notification.expire();
+                    }
+                    else if ("decline".equals(description)) {
+                        UsageTrackerManager.setOptIn(false);
+                        notification.expire();
+                    }
+                    else if ("settings".equals(description)) {
+                        final ShowSettingsUtil util = ShowSettingsUtil.getInstance();
+                        IdeFrame ideFrame = WindowManagerEx.getInstanceEx().findFrameFor(null);
+                        util.editConfigurable((JFrame)ideFrame, new GctConfigurable());
+                        notification.expire();
+                    }
+                }
+
+            }
+        };
+
+        Notification notification = new Notification(GROUP_DISPLAY_ID, title, content,
+                NotificationType.INFORMATION, listener);
+        Notifications.Bus.notify(notification);
+    }
+}


### PR DESCRIPTION
@patflynn @elharo @loosebazooka 
Will add functionality to pop up notification the first time plugin is installed.