### PR TITLE
use bundled version of mockito

### DIFF
--- a/common-lib/build.gradle
+++ b/common-lib/build.gradle
@@ -11,7 +11,7 @@ def ideaHome = '../idea-IC/'
 dependencies {
     compile files('lib/GoogleFeedback.jar')
     compile fileTree(dir: ideaHome + '/lib')
-    compile "org.mockito:mockito-all:1.9.5"
+    compile files('third_party/mockito/mockito-all-1.9.5.jar')
 
     testCompile group: 'junit', name: 'junit', version: '4.11+'
 }


### PR DESCRIPTION
@patflynn @loosebazooka This change ensures that gradkle and IDEA use the same mockito jar file. An alternative would be to remove the bundled mockiot jar, and figure out how to tell IDEA load the jar from maven central instead.