### PR TITLE
Fix external lib scopes for plugin dependencies

### DIFF
--- a/core-plugin/core-plugin.iml
+++ b/core-plugin/core-plugin.iml
@@ -65,8 +65,8 @@
     <orderEntry type="library" scope="PROVIDED" name="git4idea" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="gradle" level="project" />
     <orderEntry type="module" module-name="common-lib" />
-    <orderEntry type="library" name="properties" level="project" />
-    <orderEntry type="library" name="groovy-jps-plugin" level="project" />
-    <orderEntry type="library" name="idea-junit" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="properties" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="groovy-jps-plugin" level="project" />
+    <orderEntry type="library" scope="TEST" name="idea-junit" level="project" />
   </component>
 </module>


### PR DESCRIPTION
@patflynn @elharo I think we misconfigured these scopes, when running we get exceptions because classes are coming in from multiple places