### PR TITLE
update travis test run to use gradlew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
 jdk:
   - openjdk6
-install: ./fetchIdea.sh
 script: "./travis.sh"

--- a/travis.sh
+++ b/travis.sh
@@ -15,13 +15,13 @@
 # limitations under the License.
 
 # Run the tests
-gradle --info test
+./gradlew --info test
 
 # Was our build successful?
 stat=$?
 
 if [ "${TRAVIS}" != true ]; then
-    gradle clean
+    ./gradlew clean
     rm -rf idea-IC
 fi
 


### PR DESCRIPTION
gradlew specifices the gradle version and is the more hermetic way to run our CI tests.