### PR TITLE
Removes the Google Settings section in Settings if there is no usage tracker configured.

### DIFF
--- a/google-login-plugin/src/com/google/gct/login/stats/GoogleSettingsConfigurable.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/GoogleSettingsConfigurable.java
@@ -68,11 +68,11 @@ public class GoogleSettingsConfigurable implements SearchableConfigurable {
     @Override
     public JComponent createComponent() {
         JPanel mainPanel = new JPanel(new BorderLayout());
-
-        // Add the Usage Tracker Box
-        JPanel usageTrackerGroup = creatUsageTrackerComponent();
-        mainPanel.add(usageTrackerGroup, BorderLayout.NORTH);
-
+        if (usageTrackerManager.isUsageTrackingAvailable()) {
+            // Add the Usage Tracker Box
+            JPanel usageTrackerGroup = creatUsageTrackerComponent();
+            mainPanel.add(usageTrackerGroup, BorderLayout.NORTH);
+        }
         return mainPanel;
     }
 

--- a/google-login-plugin/src/com/google/gct/login/stats/GoogleSettingsConfigurableProvider.java
+++ b/google-login-plugin/src/com/google/gct/login/stats/GoogleSettingsConfigurableProvider.java
@@ -1,5 +1,7 @@
 package com.google.gct.login.stats;
 
+import com.google.gct.login.stats.UsageTrackerService.UsageTracker;
+
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurableProvider;
 import com.intellij.util.PlatformUtils;
@@ -21,7 +23,9 @@ public class GoogleSettingsConfigurableProvider extends ConfigurableProvider {
      */
     @Override
     public boolean canCreateConfigurable() {
-        if (PlatformUtils.isIntelliJ()) {
+        // For now we can hide Google entirely if usage tracking isn't available as there are no
+        // other Google related account settings in the IJ UI.
+        if (PlatformUtils.isIntelliJ() && UsageTrackerManager.getInstance().isUsageTrackingAvailable()) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
Also removes the opt-in setting from our Google settings panel for when
we have multiple settings and removing the whole section will be
inappropriate.  Disabling the control is not the right thing to do in
this case as it will give the user the impression that this a setting
that has a real effect but they can't change.

closes #203 