### PR TITLE
ignore test as it sometimes hangs gradle test runs

### DIFF
--- a/core-plugin/testSrc/com/google/gct/idea/debugger/ui/ExitDialogTest.java
+++ b/core-plugin/testSrc/com/google/gct/idea/debugger/ui/ExitDialogTest.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.ui.DialogWrapperPeer;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -14,6 +15,7 @@ import java.awt.Component;
 import java.awt.Container;
 import java.lang.reflect.InvocationTargetException;
 
+@Ignore
 public class ExitDialogTest {
 
   private ExitDialog dialog;


### PR DESCRIPTION
I'm finding that when this test doesn't emit the memory exceptions it just hangs and killing things leaves the java userprefs corrupted with all subsequent test runs broken. I'd like to ignore it until Elliotte's fix lands.