### PR TITLE
Force runIdea to always run even when 'up-to-date' for the core plugin

### DIFF
--- a/core-plugin/build.gradle
+++ b/core-plugin/build.gradle
@@ -14,6 +14,7 @@ project.afterEvaluate {
     project.configurations.provided.each {
         intellij.intellijFiles.add(it)
     }
+    project.tasks.runIdea.outputs.upToDateWhen { false }
 }
 
 dependencies {


### PR DESCRIPTION
If nothing had changed, runIdea would do nothing.  Which is not the right behavior.