### PR TITLE
automatically deploy binary releases to github releases upon tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,12 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+deploy:
+  provider: releases
+  api_key:
+    secure: mYd4zbP9ziojzdZwMxCCTTnvSBdeGCjs+VAFgrm5U5ZEMY9B2q1M8qbP7aYz73/lPIgwqm9gUZ7e/YxSuuH2TDaXSrj1+Yi+9SbxcduR73FsYX13g8ZGywT4ojd1Mae0+qr/mNgcl1lyLBPa09QKHm7t6NiYUpyUYy6IZanrGe9+zdaNXMhG9rhbNpTgqHn5KcQXJK9pHIGcAshAltbV6/b7f/0qzmX1MzxSO9jxx+OWhL44b1Nk2cFZvEPJ9X5ROYPOV9VHXawXNgQrI5RkUwZp3Un7uKzHVFJhhXmxlmcDT9g6m+psqIZOkcnteXlPUmKEjz1x+igCBcsiXBB+ohig0EBqPOOEwPit4xg72P87HlwV0Ya9lUP8phKFRKYbBF01acNpvpRaw1T96zgoNBjEo6fQRQVNE/LjgM3B9OfRK9ZlEFyty5RMhR3cyjWsZFLYRcwnH+vi8X9j+3TRDcXl3YZAlpY7Gshc5TWdWwdr/PEcgNOd1VbxNXE1jQ1FuZy+Q0DCWmhQQOEVUayaiIc4MReJKFqhCwp0XglLBlJQR9x1JpocBzHxuDXB5inWavNPnaJixfxYIxBUM687sIPSPkkc8ei+iBE2nOOLH0JLPl9stjr43faKcdTXZHq/RwnVNwLAsYZwRd/ZcFNrOaoPniRLJ00rW6616Pthjlk=
+  file:
+    - "google-account-plugin/build/distributions/google-account-*.zip"
+    - "core-plugin/build/distributions/google-cloud-tools-core-*.zip"
+  on:
+    tags: true


### PR DESCRIPTION
I couldn't figure out a way to test this locally so there may be some trial and error cutting releases to make sure this works.