### PR TITLE
Force the IJ provided versions of common libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,16 @@ subprojects {
         sandboxDirectory = "${rootProject.buildDir}/idea-sandbox"
     }
 
+    configurations.all {
+        resolutionStrategy {
+            failOnVersionConflict()
+            // Force the IDEA SDK provided version of these dependencies to avoid classloading issues.
+            force 'org.apache.httpcomponents:httpclient:4.4.1', 'com.google.guava:guava:17.0'
+        }
+    }
+
     dependencies {
-        compile 'com.google.guava:guava:18.0'
+        compile 'com.google.guava:guava:17.0'
 
         testCompile 'junit:junit:4.+'
         testCompile 'org.mockito:mockito-all:1.9.5'
@@ -67,6 +75,12 @@ subprojects {
     }
 
     apply plugin: 'jdepend'
+    configurations.all {
+        resolutionStrategy {
+            // JDepend manages to include a different version of itself in its own transitive closure.
+            force "jdepend:jdepend:${project.jdepend.toolVersion}"
+        }
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
Fixes #260 

IJ provides its own version of some common libraries which causes conflicts when we call across plugin barriers.  My change enforces that there are no version conflicts and that we always use the right version of the ij provided jars.