### PR TITLE
set version back to 0.9-alpha.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
     targetCompatibility = javaVersion
     tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
     group = 'com.google.gct'
-    version = '0.9-alpha.4-SNAPSHOT'
+    version = '0.9-alpha.3'
 
     apply plugin: 'org.jetbrains.intellij'
     intellij {


### PR DESCRIPTION
My strategy didn't work.  You can't create a release tag in github on an intermediary commit in a PR. Only on merge PRs.