### PR TITLE
Set version to 0.9.1-alpha-SNAPHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
     targetCompatibility = javaVersion
     tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
     group = 'com.google.gct'
-    version = '0.9-alpha.3'
+    version = '0.9.1-alpha-SNAPSHOT'
 
     apply plugin: 'org.jetbrains.intellij'
     intellij {


### PR DESCRIPTION
Note, next planned release will be before the holidays and targets MVM deployment.