### PR TITLE
remove irrelevant, inactive Drop Frame button

### DIFF
--- a/core-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
+++ b/core-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
@@ -24,7 +24,7 @@ import com.google.gct.idea.ui.GoogleCloudToolsIcons;
 import com.google.gct.idea.util.GctBundle;
 import com.google.gct.idea.util.GctTracking;
 import com.google.gct.stats.UsageTrackerProvider;
-
+import com.intellij.debugger.actions.DebuggerActions;
 import com.intellij.debugger.ui.DebuggerContentInfo;
 import com.intellij.debugger.ui.breakpoints.BreakpointManager;
 import com.intellij.execution.ExecutionBundle;
@@ -58,17 +58,15 @@ import com.intellij.xdebugger.evaluation.XDebuggerEditorsProvider;
 import com.intellij.xdebugger.frame.XExecutionStack;
 import com.intellij.xdebugger.frame.XSuspendContext;
 import com.intellij.xdebugger.ui.XDebugTabLayouter;
-
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.java.debugger.JavaDebuggerEditorsProvider;
 
+import javax.swing.SwingUtilities;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.List;
-
-import javax.swing.SwingUtilities;
 
 /**
  * CloudDebugProcess is the controller that represents our attached state to the server. It provides the breakpoint
@@ -375,6 +373,7 @@ public class CloudDebugProcess extends XDebugProcess implements CloudBreakpointL
     topToolbar.remove(manager.getAction(XDebuggerActions.STEP_OUT));
     topToolbar.remove(manager.getAction(XDebuggerActions.RUN_TO_CURSOR));
     topToolbar.remove(manager.getAction(XDebuggerActions.EVALUATE_EXPRESSION));
+    topToolbar.remove(manager.getAction(DebuggerActions.POP_FRAME));
   }
 
   public void removeListener(@NotNull CloudBreakpointListener listener) {

--- a/core-plugin/testSrc/com/google/gct/idea/debugger/CloudDebugProcessTest.java
+++ b/core-plugin/testSrc/com/google/gct/idea/debugger/CloudDebugProcessTest.java
@@ -1,6 +1,7 @@
 package com.google.gct.idea.debugger;
 
 import com.google.api.client.util.Lists;
+import com.intellij.debugger.actions.DebuggerActions;
 import com.intellij.debugger.ui.DebuggerContentInfo;
 import com.intellij.execution.ui.RunnerLayoutUi;
 import com.intellij.execution.ui.layout.LayoutStateDefaults;
@@ -128,6 +129,12 @@ public class CloudDebugProcessTest extends PlatformTestCase {
     @Test
     public void testRegisterAdditionalActions_evaluate() {
         assertRemoveFromTopToolbar(XDebuggerActions.EVALUATE_EXPRESSION);
+    }
+
+    @Test
+    public void testRegisterAdditionalActions_dropFrame() {
+        // name of constant "POP_FRAME" and UI label "Drop Frame" are inconsistent
+        assertRemoveFromTopToolbar(DebuggerActions.POP_FRAME);
     }
 
     private void assertRemoveFromLeftToolbar(String actionId) {


### PR DESCRIPTION
@patflynn The button I'm removing is inherited from the regular IntelliJ debugger, but is always inactive in the Cloud Debugger. In the local debugger it reverses the execution by one stack frame (neat trick) but this is not something Cloud Debugger can do. 

close #282 
