### PR TITLE
Remove single quotes from JB repo publish channel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 ideaVersion = IC-15.0.1
 javaVersion = 1.6
-ijPluginRepoChannel = 'alpha'
+ijPluginRepoChannel = alpha


### PR DESCRIPTION
the quotes were showing up as part of the channel string, so that they had to be included in the repostiroy URL.