### PR TITLE
Mostly safe refactorings of CloudDebugHistoricalSnapshots

### DIFF
--- a/core-plugin/src/com/google/gct/idea/debugger/CloudBreakpointHandler.java
+++ b/core-plugin/src/com/google/gct/idea/debugger/CloudBreakpointHandler.java
@@ -52,7 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * the local IDE representation and the server breakpoint and provides methods for getting one given the other. {@link
  * XBreakpointHandler} is often called by intelliJ when the user enables or disables breakpoints.
  * <p/>
- * This class is threadsafe in that all operations can be called by multiple threads.
+ * This class is threadsafe. All operations can be called by multiple threads.
  * <p/>
  * Note there are three breakpoint types managed in the debugger and are named to avoid confusion:
  * xIdeBreakpoint : these are {@link XBreakpoint} types that intelliJ defines and are sealed.
@@ -79,8 +79,10 @@ public class CloudBreakpointHandler extends XBreakpointHandler<XLineBreakpoint<C
    * Called when the user "reactivates" an existing snapshot to create a new breakpoint, this clones state into a new
    * breakpoint. It is different from "createIdeRepresentationsIfNecessary" in the following respects:
    * <p/>
-   * 1. it only operates on final state breakpoints. 2. it always clones them into a new IDE breakpoint 3. it does not
-   * set "created by server = true", so when control flow comes back into register, it will register with the server.
+   * 1. It only operates on final state breakpoints.
+   * 2. It always clones them into a new IDE breakpoint
+   * 3. It does not set "created by server = true", so when control flow comes back into register,
+   *    it will register with the server.
    */
   public void cloneToNewBreakpoints(@NotNull final List<Breakpoint> serverBreakpoints) {
     for (Breakpoint serverBreakpoint : serverBreakpoints) {

--- a/core-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
+++ b/core-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
@@ -261,7 +261,7 @@ public class CloudDebugProcess extends XDebugProcess implements CloudBreakpointL
             SwingUtilities.invokeLater(new Runnable() {
               @Override
               public void run() {
-                //We will only do the selection if the id for this async task matches the latest
+                // We will only do the selection if the id for this async task matches the latest
                 // user clicked item.  This prevents multiple (and possibly out of order) selections
                 // getting queued up.
                 if (id.equals(myNavigatedSnapshotId)) {

--- a/core-plugin/src/com/google/gct/idea/debugger/CloudExecutionStack.java
+++ b/core-plugin/src/com/google/gct/idea/debugger/CloudExecutionStack.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * CloudExecutionStack represents an entire stack for a {@link com.google.api.services.debugger .model.Breakpoint} It
+ * CloudExecutionStack represents an entire stack for a {@link com.google.api.services.debugger.model.BreakPoint} It
  * stores the individual frames, and also the variables and custom watch expressions.
  */
 public class CloudExecutionStack extends XExecutionStack {

--- a/core-plugin/src/com/google/gct/idea/debugger/actions/CloudDebugHelpAction.java
+++ b/core-plugin/src/com/google/gct/idea/debugger/actions/CloudDebugHelpAction.java
@@ -7,8 +7,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.util.IconLoader;
 
-import org.jetbrains.annotations.Nullable;
-
 import javax.swing.Icon;
 
 /**


### PR DESCRIPTION
@patflynn This cl performs a number of relatively safe, automatic refactorings in the CloudDebugHistoricalSnapshots class and a few related classes. It also expands on the intenral documentation in the comments. The main refactoring that was performed was pulling out a lot of anonymous inner classes into non-anonymous inner classes. 

Step 2 is going to be to further separate the model from the GUI so we can better test this code. 