### PR TITLE
Add a Gradle release plugin for automation of version updating and tag creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,6 @@ deploy:
     - ${HOME}/build/${TRAVIS_REPO_SLUG}/core-plugin/build/distributions/google-cloud-tools-core-*.zip
   on:
     tags: true
+    condition: "$TRAVIS_TAG =~ ^v[0-9]+.*$"
 after_deploy:
   - ./gradlew publishPlugin

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
@@ -6,6 +5,10 @@ buildscript {
     dependencies {
         classpath 'gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.0.35'
     }
+}
+
+plugins {
+    id 'net.researchgate.release' version '2.3.4'
 }
 
 subprojects {
@@ -18,7 +21,6 @@ subprojects {
     targetCompatibility = javaVersion
     tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
     group = 'com.google.gct'
-    version = '0.9.1-alpha-SNAPSHOT'
 
     apply plugin: 'org.jetbrains.intellij'
     intellij {
@@ -80,4 +82,26 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+release {
+    buildTasks = ['doRelease']
+    // Do not change the tagTemplate value to double quotes or the version will be evaluated before
+    // the SNAPSHOT version is updated to the release version.
+    tagTemplate = 'v$version'
+    git {
+        requireBranch = /^release_v\d+.*$/
+    }
+}
+
+// We aren't building or doing anything interesting for release.
+// We just update the version and generate the tag as CI will handle deployment.
+task doRelease {
+    doLast {
+        println '===============================!!PLEASE READ!!=================================\n\n' +
+                'IMPORTANT:  The release command will trigger the creation of a new release ' +
+                'in Github, the uploading of binaries to github, and the publishing of our plugin' +
+                'to the IntelliJ plugin repository.\n' +
+                'Hit CTRL+C to cancel.\n'
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 ideaVersion = IC-15.0.2
 javaVersion = 1.6
 ijPluginRepoChannel = alpha
+version = 0.9.1-alpha-SNAPSHOT


### PR DESCRIPTION
I've added and configured the [researchgate gradle release plugin](https://github.com/researchgate/gradle-release) to our build.gradle.  It should allow those with push access to our master branch to be able to create a release using `gradlew release` from the command line.
