### PR TITLE
Rename cloud tools plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ channel. To install them please perform the following steps:
     1. Copy this URL `https://plugins.jetbrains.com/plugins/alpha/8078`
     1. Use the copied URL as the Custom Plugin URL when following [these instrucions](https://www.jetbrains.com/idea/help/managing-enterprise-plugin-repositories.html)
     1. Search for the 'Google Account' plugin in the plugin manager and install it.
-1. Install the Google Cloud Tools Core plugin
+1. Install the Google Cloud Tools plugin
     1. Use the same steps as step 1 but use the following URL `https://plugins.jetbrains.com/plugins/alpha/8079`
-    1. When installing look for the 'Google Cloud Tools Core' plugin.
+    1. When installing look for the 'Google Cloud Tools' plugin.
 
 If you wish to build this plugin from source, please see the
 [contributor instructions](https://github.com/GoogleCloudPlatform/gcloud-intellij/blob/master/CONTRIBUTING.md).

--- a/core-plugin/build.gradle
+++ b/core-plugin/build.gradle
@@ -5,7 +5,7 @@ sourceSets.test.java.srcDirs = ['testSrc']
 sourceSets.test.resources.srcDirs = ['testResources']
 
 intellij {
-    pluginName = 'google-cloud-tools-core'
+    pluginName = 'google-cloud-tools'
     plugins 'Groovy','gradle', 'git4idea', 'properties', 'junit'
 
     publish {

--- a/core-plugin/resources/META-INF/plugin.xml
+++ b/core-plugin/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin version="2">
   <id>com.google.gct.core</id>
-  <name>Google Cloud Tools Core</name>
+  <name>Google Cloud Tools</name>
   <description>Debug Java applications running in the Google cloud from inside IDEA.
 Code inspections for AppEngine Java code.</description>
   <vendor>Google</vendor>


### PR DESCRIPTION
 Renaming our plugin from 'Google Cloud Tools Core' to 'Gogle Cloud Tools'.

Relates to #354 