### PR TITLE
only warn user about local repo SHA mismatch if sync is needed

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
@@ -264,6 +264,15 @@ public class CloudAttachDialog extends DialogWrapper {
       myWarningLabel2.setVisible(false);
       myInfoPanel.setVisible(true);
     }
+    else if (mySyncResult.needsSync() && mySyncResult.getTargetSyncSHA() == null) {
+      setOKButtonText(isContinued()
+              ? GctBundle.getString("clouddebug.continueanyway")
+              : GctBundle.getString("clouddebug.attach.anyway"));
+      myWarningLabel.setVisible(true);
+      myWarningLabel2.setVisible(true);
+      myInfoPanel.setVisible(true);
+      myWarningLabel2.setText(GctBundle.getString("clouddebug.no.matching.sha"));
+    }
     else if (mySyncResult.needsSync()) {
       setOKButtonText(isContinued()
           ? GctBundle.getString("clouddebug.continuesession")
@@ -275,15 +284,6 @@ public class CloudAttachDialog extends DialogWrapper {
       myWarningLabel.setVisible(false);
       myWarningLabel2.setVisible(false);
       myInfoPanel.setVisible(true);
-    }
-    else if (mySyncResult.getTargetSyncSHA() == null) {
-      setOKButtonText(isContinued()
-          ? GctBundle.getString("clouddebug.continueanyway")
-          : GctBundle.getString("clouddebug.attach.anyway"));
-      myWarningLabel.setVisible(true);
-      myWarningLabel2.setVisible(true);
-      myInfoPanel.setVisible(true);
-      myWarningLabel2.setText(GctBundle.getString("clouddebug.no.matching.sha"));
     }
     else if (!mySyncResult.hasRemoteRepository()) {
       setOKButtonText(isContinued()


### PR DESCRIPTION
We only want to warn the user about a missing local repo with matching SHA if a sync is needed.  Issue #366 