### PR TITLE
initial push to create test coverage for the attach debug dialog

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/DebugTarget.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/DebugTarget.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gct.idea.debugger.ui;
+
+import com.google.api.services.clouddebugger.model.Debuggee;
+import com.google.common.base.Strings;
+import com.google.gct.idea.util.GctBundle;
+
+import com.intellij.openapi.diagnostic.Logger;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+/**
+ * The class models out the details for a target dubuggable module.
+ */
+class DebugTarget {
+  private static final Logger LOG = Logger.getInstance(DebugTarget.class);
+  private static final String MODULE = "module";
+
+  private final Debuggee myDebuggee;
+  private String myDescription;
+  private long myMinorVersion = 0;
+  private String myModule;
+  private String myVersion;
+
+  public DebugTarget(@NotNull Debuggee debuggee, @NotNull String projectName) {
+    myDebuggee = debuggee;
+    if (myDebuggee.getLabels() != null) {
+      myDescription = "";
+      myModule = "";
+      myVersion = "";
+      String minorVersion = "";
+
+      //Get the module name, major version and minor version strings.
+      for (Map.Entry<String, String> entry : myDebuggee.getLabels().entrySet()) {
+        if (entry.getKey().equalsIgnoreCase(MODULE)) {
+          myModule = entry.getValue();
+        }
+        else if (entry.getKey().equalsIgnoreCase("minorversion")) {
+          minorVersion = entry.getValue();
+        }
+        else if (entry.getKey().equalsIgnoreCase("version")) {
+          myVersion = entry.getValue();
+        }
+        else {
+          //This is fallback logic where we dump the labels verbatim if they
+          //change from underneath us.
+          myDescription += String.format("%s:%s", entry.getKey(), entry.getValue());
+        }
+      }
+
+      //Build a description from the strings.
+      if (!Strings.isNullOrEmpty(myModule)) {
+        myDescription = GctBundle.getString("clouddebug.version.with.module.format",
+            myModule, myVersion);
+      }
+      else if (!Strings.isNullOrEmpty(myVersion)) {
+        myDescription = GctBundle.getString("clouddebug.versionformat", myVersion);
+      }
+
+      //Record the minor version.  We only show the latest minor version.
+      try {
+        if (!Strings.isNullOrEmpty(minorVersion)) {
+          myMinorVersion = Long.parseLong(minorVersion);
+        }
+      }
+      catch(NumberFormatException ex) {
+        LOG.warn("unable to parse minor version: " + minorVersion);
+      }
+    }
+
+    //Finally if nothing worked (maybe labels aren't enabled?), we fall
+    //back to the old logic of using description with the project name stripped out.
+    if (Strings.isNullOrEmpty(myDescription)) {
+      myDescription = myDebuggee.getDescription();
+      if (myDescription != null &&
+          !Strings.isNullOrEmpty(projectName) &&
+          myDescription.startsWith(projectName + "-")) {
+        myDescription = myDescription.substring(projectName.length() + 1);
+      }
+    }
+  }
+
+  public String getId() {
+    return myDebuggee.getId();
+  }
+
+  @Override
+  public String toString() {
+    return myDescription;
+  }
+
+  public long getMinorVersion() {
+    return myMinorVersion;
+  }
+
+  public String getModule() {
+    return myModule;
+  }
+
+  public String getVersion() {
+    return myVersion;
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/ProjectDebuggeeBinding.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/ProjectDebuggeeBinding.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gct.idea.debugger.ui;
+
+import com.google.api.services.clouddebugger.Clouddebugger.Debugger;
+import com.google.api.services.clouddebugger.model.Debuggee;
+import com.google.api.services.clouddebugger.model.ListDebuggeesResponse;
+import com.google.common.base.Strings;
+import com.google.gct.idea.debugger.CloudDebugProcessState;
+import com.google.gct.idea.debugger.CloudDebuggerClient;
+import com.google.gct.idea.elysium.ProjectSelector;
+import com.google.gct.idea.util.GctBundle;
+import com.google.gct.login.CredentialedUser;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.DocumentAdapter;
+import com.intellij.util.containers.HashMap;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.swing.JComboBox;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.TreeModelEvent;
+import javax.swing.event.TreeModelListener;
+
+/**
+ * This binding between the project and debuggee is refactored out to make it reusable in the future.
+ */
+class ProjectDebuggeeBinding {
+  private static final Logger LOG = Logger.getInstance(ProjectDebuggeeBinding.class);
+  private final JComboBox myDebugeeTarget;
+  private final ProjectSelector myElysiumProjectId;
+  private Debugger myCloudDebuggerClient = null;
+  private CredentialedUser myCredentialedUser = null;
+  private CloudDebugProcessState myInputState;
+
+  public ProjectDebuggeeBinding(@NotNull ProjectSelector elysiumProjectId, @NotNull JComboBox debugeeTarget) {
+    myElysiumProjectId = elysiumProjectId;
+    myDebugeeTarget = debugeeTarget;
+
+    myElysiumProjectId.getDocument().addDocumentListener(new DocumentAdapter() {
+      @Override
+      protected void textChanged(DocumentEvent e) {
+        refreshDebugTargetList();
+      }
+    });
+
+    myElysiumProjectId.addModelListener(new TreeModelListener() {
+      @Override
+      public void treeNodesChanged(TreeModelEvent e) {
+      }
+
+      @Override
+      public void treeNodesInserted(TreeModelEvent e) {
+      }
+
+      @Override
+      public void treeNodesRemoved(TreeModelEvent e) {
+      }
+
+      @Override
+      public void treeStructureChanged(TreeModelEvent e) {
+        refreshDebugTargetList();
+      }
+    });
+  }
+
+  @NotNull
+  public CloudDebugProcessState buildResult(Project project) {
+    Long number = myElysiumProjectId.getProjectNumber();
+    String projectNumberString = number != null ? number.toString() : null;
+    DebugTarget selectedItem = (DebugTarget)myDebugeeTarget.getSelectedItem();
+    String savedDebuggeeId = selectedItem != null ? selectedItem.getId() : null;
+    String savedProjectDescription = myElysiumProjectId.getText();
+
+    return new CloudDebugProcessState(myCredentialedUser != null ? myCredentialedUser.getEmail() : null,
+        savedDebuggeeId,
+        savedProjectDescription,
+        projectNumberString,
+        project);
+  }
+
+  @Nullable
+  public Debugger getCloudDebuggerClient() {
+    CredentialedUser credentialedUser = myElysiumProjectId.getSelectedUser();
+    if (myCredentialedUser == credentialedUser) {
+      return myCloudDebuggerClient;
+    }
+
+    myCredentialedUser = credentialedUser;
+    myCloudDebuggerClient =
+        myCredentialedUser != null ? CloudDebuggerClient.getLongTimeoutClient(myCredentialedUser.getEmail()) : null;
+
+    return myCloudDebuggerClient;
+  }
+
+  @Nullable
+  public CloudDebugProcessState getInputState() {
+    return myInputState;
+  }
+
+  public void setInputState(@Nullable CloudDebugProcessState inputState) {
+    myInputState = inputState;
+    if (myInputState != null) {
+      myElysiumProjectId.setText(myInputState.getProjectName());
+    }
+  }
+
+  /**
+   * Refreshes the list of attachable debug targets based on the project selection.
+   */
+  @SuppressWarnings("unchecked")
+  private void refreshDebugTargetList() {
+    myDebugeeTarget.removeAllItems();
+    ApplicationManager.getApplication().executeOnPooledThread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          if (myElysiumProjectId.getProjectNumber() != null && getCloudDebuggerClient() != null) {
+              final ListDebuggeesResponse debuggees =
+                  getCloudDebuggerClient().debuggees().list()
+                      .setProject(myElysiumProjectId.getProjectNumber().toString())
+                      .execute();
+
+            SwingUtilities.invokeLater(new Runnable() {
+              @Override
+              public void run() {
+                DebugTarget targetSelection = null;
+
+                if (debuggees == null || debuggees.getDebuggees() == null || debuggees.getDebuggees().isEmpty()) {
+                  myDebugeeTarget.setEnabled(false);
+                  myDebugeeTarget.addItem(GctBundle.getString("clouddebug.nomodulesfound"));
+                }
+                else {
+                  myDebugeeTarget.setEnabled(true);
+                  Map<String, DebugTarget> perModuleCache = new HashMap<String, DebugTarget>();
+
+                  for (Debuggee debuggee : debuggees.getDebuggees()) {
+                    DebugTarget item = new DebugTarget(debuggee, myElysiumProjectId.getText());
+                    if (!Strings.isNullOrEmpty(item.getModule()) &&
+                        !Strings.isNullOrEmpty(item.getVersion())) {
+                      //If we already have an existing item for that module+version, compare the minor
+                      // versions and only use the latest minor version.
+                      String key = String.format("%s:%s", item.getModule(), item.getVersion());
+                      DebugTarget existing = perModuleCache.get(key);
+                      if (existing != null && existing.getMinorVersion() > item.getMinorVersion()) {
+                        continue;
+                      }
+                      if (existing != null) {
+                        myDebugeeTarget.removeItem(existing);
+                      }
+                      perModuleCache.put(key, item);
+                    }
+                    if (myInputState != null && !Strings.isNullOrEmpty(myInputState.getDebuggeeId())) {
+                      assert myInputState.getDebuggeeId() != null;
+                      if (myInputState.getDebuggeeId().equals(item.getId())) {
+                        targetSelection = item;
+                      }
+                    }
+                    myDebugeeTarget.addItem(item);
+                  }
+                }
+                if (targetSelection != null) {
+                  myDebugeeTarget.setSelectedItem(targetSelection);
+                }
+              }
+            });
+          }
+        } catch (IOException ex) {
+          LOG.error("Error listing debuggees from Cloud Debugger API", ex);
+        }
+      }
+    });
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/debugger/ui/CloudAttachDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/debugger/ui/CloudAttachDialogTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.gct.idea.debugger.ui;
+
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.services.clouddebugger.model.Debuggee;
+import com.google.gct.idea.elysium.ProjectSelector;
+import com.google.gct.login.CredentialedUser;
+import com.google.gct.login.GoogleLogin;
+import com.google.gct.login.MockGoogleLogin;
+import com.google.gdt.eclipse.login.common.GoogleLoginState;
+
+import com.intellij.openapi.ui.ValidationInfo;
+import com.intellij.testFramework.PlatformTestCase;
+
+import org.mockito.Mockito;
+
+import java.util.LinkedHashMap;
+
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+
+public class CloudAttachDialogTest extends PlatformTestCase {
+  private static final String NO_LOGIN_WARNING = "You must be logged in to perform this action.";
+  private static final String NO_PROJECT_ID_WARNING = "Please enter a Project ID.";
+  private static final String NO_MODULES_WARNING = "No debuggable modules found.";
+  private static final String SELECT_VALID_PROJECT_WARNING = "Please select a project with debuggable modules.";
+
+  private static final String USER = "test@user.com";
+  private static final String PASSWORD = "123";
+  private CredentialedUser user;
+
+  private ProjectSelector projectSelector;
+  private CloudAttachDialog dialog;
+  private JComboBox moduleSelector;
+  private JLabel warningHeader;
+  private JLabel warningMessage;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    mockCredentials();
+
+    dialog = new CloudAttachDialog(this.getProject());
+    projectSelector = dialog.getElysiumProjectSelector();
+    moduleSelector = dialog.getDebuggeeTarget();
+    warningHeader = dialog.getWarningHeader();
+    warningMessage = dialog.getWarningMessage();
+  }
+
+  public void testErrorWhenUserIsLoggedOut() {
+    mockLoggedOutUser();
+    ValidationInfo error = dialog.doValidate();
+
+    assertNotNull(error);
+    assertEquals(NO_LOGIN_WARNING, error.message);
+  }
+
+  public void testErrorWhenNoProjectSelected() {
+    mockLoggedInUser();
+    ValidationInfo error = getValidationError();
+
+    assertNotNull(error);
+    assertEquals(NO_PROJECT_ID_WARNING, error.message);
+  }
+
+  public void testNoModulesFound() {
+    mockLoggedInUser();
+    selectEmptyProject();
+    ValidationInfo error = getValidationError();
+
+    // Errors
+    assertNotNull(error);
+    assertEquals(SELECT_VALID_PROJECT_WARNING, error.message);
+
+    // Warnings
+    assertFalse(warningMessage.isVisible());
+    assertFalse(warningHeader.isVisible());
+
+    // Module selector
+    assertFalse(moduleSelector.isEnabled());
+  }
+
+  public void testDebuggableModuleSelected() {
+    mockLoggedInUser();
+    selectProjectWithDebuggableModules();
+    ValidationInfo error = getValidationError();
+
+    // Errors
+    assertNull(error);
+
+    // TODO: complete these once CloudAttachDialog is further refactored for testability
+    // Warnings
+//    assertFalse(warningMessage.isVisible());
+//    assertFalse(warningHeader.isVisible());
+
+    // Module selector
+//    assertTrue(moduleSelector.isEnabled());
+  }
+
+  @SuppressWarnings("unchecked")
+  private void selectEmptyProject() {
+    projectSelector.setText("emptyProject");
+    moduleSelector.setEnabled(false);
+    moduleSelector.addItem(NO_MODULES_WARNING);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void selectProjectWithDebuggableModules() {
+    String projectName = "projectWithDebuggableModules";
+    projectSelector.setText(projectName);
+    moduleSelector.setEnabled(true);
+
+    DebugTarget debugTarget = new DebugTarget(new Debuggee(), projectName);
+    moduleSelector.addItem(debugTarget);
+  }
+
+  private ValidationInfo getValidationError() {
+    return dialog.doValidate();
+  }
+
+  private void mockCredentials() throws Exception {
+    MockGoogleLogin googleLogin = new MockGoogleLogin();
+    googleLogin.install();
+
+    GoogleLoginState googleLoginState = Mockito.mock(GoogleLoginState.class);
+    Credential credential = Mockito.mock(Credential.class);
+    this.user = Mockito.mock(CredentialedUser.class);
+    LinkedHashMap<String, CredentialedUser> allusers = new LinkedHashMap<String, CredentialedUser>();
+
+    when(this.user.getCredential()).thenReturn(credential);
+    when(this.user.getEmail()).thenReturn(USER);
+    when(this.user.getGoogleLoginState()).thenReturn(googleLoginState);
+    when(googleLoginState.fetchAccessToken()).thenReturn(PASSWORD);
+    when(GoogleLogin.getInstance().getAllUsers()).thenReturn(allusers);
+    allusers.put(USER, this.user);
+  }
+
+  private void mockLoggedOutUser() {
+    when(GoogleLogin.getInstance().isLoggedIn()).thenReturn(false);
+  }
+
+  private void mockLoggedInUser() {
+    when(GoogleLogin.getInstance().isLoggedIn()).thenReturn(true);
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    dialog.close(0);
+    super.tearDown();
+  }
+}


### PR DESCRIPTION
See #373 

Added some basic tests for the CloudAttachDialog class. I'm finding it difficult to test certain more complex functionality in this class (i.e. when the debuggable modules have been loaded) due to the current architecture of the class. I'll continue to explore ways to refactor it. In the meantime for the sake of keeping the cl smaller, I'm putting this out there.

Refactoring included to support the tests so far:
- Added several package private getters so that the tests can inspect the state of various errors and warnings. 
- Extracted out the inner classes of CloudAttachDialog into their own top level classes to support injection by the tests