### PR TITLE
auto generating copyright headers for new project files

### DIFF
--- a/.idea/copyright/Android_Copyright.xml
+++ b/.idea/copyright/Android_Copyright.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="myName" value="Android Copyright" />
+    <option name="notice" value="Copyright (C) 2015 The Android Open Source Project&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;     http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,3 +1,7 @@
 <component name="CopyrightManager">
-  <settings default="" />
+  <settings default="Android Copyright">
+    <module2copyright>
+      <element module="All" copyright="Android Copyright" />
+    </module2copyright>
+  </settings>
 </component>


### PR DESCRIPTION
fixes #403 

simple project setting update - requires copyright plugin to be installed (which I believe is the default).