### PR TITLE
Adds the plugin version to the set of crash report values sent for error reporting

### DIFF
--- a/common-lib/src/main/java/com/google/gct/idea/feedback/GoogleFeedbackErrorReporter.java
+++ b/common-lib/src/main/java/com/google/gct/idea/feedback/GoogleFeedbackErrorReporter.java
@@ -73,6 +73,8 @@ public class GoogleFeedbackErrorReporter extends ErrorReportSubmitter {
   static final String APP_VERSION_MAJOR_KEY = "app.version.major";
   @VisibleForTesting
   static final String APP_VERSION_MINOR_KEY = "app.version.minor";
+  @VisibleForTesting
+  static final String PLUGIN_VERSION = "plugin.version";
 
   @Override
   public String getReportActionText() {
@@ -172,7 +174,7 @@ public class GoogleFeedbackErrorReporter extends ErrorReportSubmitter {
         // required parameters
         .put(ERROR_MESSAGE_KEY, nullToNone(error.getMessage()))
         .put(ERROR_STACKTRACE_KEY, nullToNone(error.getStackTrace()))
-            // end or required parameters
+        // end or required parameters
         .put(ERROR_DESCRIPTION_KEY, nullToNone(error.getDescription()))
         .put(LAST_ACTION_KEY, nullToNone(error.getLastAction()))
         .put(OS_NAME_KEY, SystemProperties.getOsName())
@@ -185,7 +187,9 @@ public class GoogleFeedbackErrorReporter extends ErrorReportSubmitter {
         .put(APP_INTERNAL_KEY, Boolean.toString(application.isInternal()))
         .put(APP_VERSION_MAJOR_KEY, intelliJAppExtendedInfo.getMajorVersion())
         .put(APP_VERSION_MINOR_KEY, intelliJAppExtendedInfo.getMinorVersion())
+        .put(PLUGIN_VERSION, error.getPluginVersion())
         .build();
+
     return params;
   }
 

--- a/common-lib/src/test/java/com/google/gct/idea/feedback/GoogleFeedbackErrorReporterTest.java
+++ b/common-lib/src/test/java/com/google/gct/idea/feedback/GoogleFeedbackErrorReporterTest.java
@@ -30,6 +30,7 @@ public class GoogleFeedbackErrorReporterTest {
   private static final String VERSION_NAME = "version name";
   private static final String MAJOR_VERSION = "major version";
   private static final String MINOR_VERSION = "minor version";
+  private static final String PLUGIN_VERSION = "plugin version";
 
   @Mock
   private ApplicationNamesInfo mockAppNameInfo;
@@ -44,6 +45,7 @@ public class GoogleFeedbackErrorReporterTest {
   @Before
   public void setUp() {
     error = new ErrorBean(new Throwable(TEST_MESSAGE), LAST_ACTION);
+    error.setPluginVersion(PLUGIN_VERSION);
     when(mockAppNameInfo.getFullProductName()).thenReturn(FULL_PRODUCT_NAME);
     when(mockAppInfoEx.getPackageCode()).thenReturn(PACKAGE_CODE);
     when(mockAppInfoEx.getVersionName()).thenReturn(VERSION_NAME);
@@ -65,6 +67,7 @@ public class GoogleFeedbackErrorReporterTest {
     assertEquals(Boolean.TRUE.toString(), result.get(GoogleFeedbackErrorReporter.APP_INTERNAL_KEY));
     assertEquals(MAJOR_VERSION, result.get(GoogleFeedbackErrorReporter.APP_VERSION_MAJOR_KEY));
     assertEquals(MINOR_VERSION, result.get(GoogleFeedbackErrorReporter.APP_VERSION_MINOR_KEY));
+    assertEquals(PLUGIN_VERSION, result.get(GoogleFeedbackErrorReporter.PLUGIN_VERSION));
   }
 
   @Test


### PR DESCRIPTION
It turns out we don't need to package the version ourselves since it's included in the plugin.xml. 

Funny story, I have a CL at work that starts this work from the other end of including the version using resource filtering etc. 

Fixes #333  