### PR TITLE
removing reliance on Thread.sleep from snapshot unit tests, refactori…

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
@@ -141,6 +141,7 @@ public class CloudDebugProcess extends XDebugProcess implements CloudBreakpointL
         }
 
         CloudDebugHistoricalSnapshots timeline = new CloudDebugHistoricalSnapshots(handler);
+        timeline.onBreakpointListChanged(getProcessState());
         Content snapshots = layout
           .createContent(timeline.getTabTitle(), (ComponentWithActions)timeline, timeline.getTabTitle(),
                          GoogleCloudToolsIcons.CLOUD, null);


### PR DESCRIPTION
…ng shared state, and removing @Ignore

Fixes #187 

Revives CloudHistoricalSnapshotsTest which was previously ignored due to unpredictable failures. 

- Un-ignoring the unit test
- Refactoring associated classes for testability
- Removing shared state from the unit test, and removing call to asynchronous method from CloudHistoricalSnapshots (instead moving it to the caller). These were the sources of the problems with this test.