### PR TITLE
forcing redraw of snapshot results when snapshot was pre-selected in …

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
@@ -286,9 +286,7 @@ public class CloudDebugProcess extends XDebugProcess implements CloudBreakpointL
                     return;
                   }
 
-                  if (myCurrentSnapshot == null || !myCurrentSnapshot.getId().equals(result.getId())) {
-                    navigateToBreakpoint(result);
-                  }
+                  navigateToBreakpoint(result);
                 }
               }
             });


### PR DESCRIPTION
…pending state

Fixes #416 

The issue was that when the user selected a snapshot (by clicking on the row in the IJ debug window) prior to the snapshot being triggered, the results were not being redrawn when the data came in. Previously the stack frames and variables were only redrawn on a mouse click; and the mouse click is ignored if it was a click on an already selected row.

The solution is to force redraw the results when they come in if the row was _already_ selected before they came in.