### PR TITLE
Disables Attach button in the presence of an unexisting project ID.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
@@ -197,12 +197,19 @@ public class CloudAttachDialog extends DialogWrapper {
     // validation should run only after the query for debug targets has results
     // assumption: either an ErrorHolder or one or more DebugTargets are added to the selector when
     //             the result is available
-    if (!targetSelector.isEnabled() && targetSelector.getItemCount() > 0) {
-      if (targetSelector.getSelectedItem() instanceof ErrorHolder) {
-        return new ValidationInfo(((ErrorHolder) targetSelector.getSelectedItem()).getErrorMessage(),
-            elysiumProjectSelector);
-      } else {
-        return new ValidationInfo(GctBundle.getString("clouddebug.selectvalidproject"),
+    if (!targetSelector.isEnabled()) {
+      if (targetSelector.getItemCount() > 0) {
+        if (targetSelector.getSelectedItem() instanceof ErrorHolder) {
+          return new ValidationInfo(
+              ((ErrorHolder) targetSelector.getSelectedItem()).getErrorMessage(),
+              elysiumProjectSelector);
+        } else {
+          return new ValidationInfo(GctBundle.getString("clouddebug.selectvalidproject"),
+              elysiumProjectSelector);
+        }
+      } else if (wireup.isCdbQueried()) {
+        // We went to CDB and detected no debuggees.
+        return new ValidationInfo(GctBundle.getString("clouddebug.debug.targets.accessdenied"),
             elysiumProjectSelector);
       }
     }

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/debugger/ui/CloudAttachDialogTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/debugger/ui/CloudAttachDialogTest.java
@@ -145,6 +145,8 @@ public class CloudAttachDialogTest extends PlatformTestCase {
     assertNull(error);
     assertFalse(targetSelector.isEnabled());
     assertNull(targetSelector.getSelectedItem());
+    // We want to make sure that the OK button is disabled, though.
+    assertFalse(dialog.isOKActionEnabled());
 
     dialog.close(0);
   }


### PR DESCRIPTION
Does so in a way where attach dialog doesn't start with an error message.

Fixes #430 
@etanshaul @loosebazooka @elharo 