### PR TITLE
manually setting plugin version range so that we can cover versions 1…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ subprojects {
     apply plugin: 'org.jetbrains.intellij'
     intellij {
         version = ideaVersion
+        updateSinceUntilBuild = false
         downloadSources = true
         sandboxDirectory = "${rootProject.buildDir}/idea-sandbox"
 

--- a/google-account-plugin/resources/META-INF/plugin.xml
+++ b/google-account-plugin/resources/META-INF/plugin.xml
@@ -19,6 +19,9 @@
   <vendor>Google</vendor>
   <!-- "version" set by gradle-intellij-plugin -->
   <!-- "idea-version since-build" set by gradle-intellij-plugin -->
+  <!-- Workaround for gradle-intellij-plugin limitation: https://github.com/JetBrains/gradle-intellij-plugin/issues/66 -->
+  <!-- Setting version to 15.0.3 and up. https://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+15+143.1821.5+Release+Notes -->
+  <idea-version since-build="143.1821.5" />
 
   <description>
     Provides Google account setting and authentication for IntelliJ plugins that need it.

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -6,6 +6,9 @@ Code inspections for AppEngine Java code.</description>
   <vendor>Google</vendor>
   <!-- "version" set by gradle-intellij-plugin -->
   <!-- "idea-version since-build" set by gradle-intellij-plugin -->
+  <!-- Workaround for gradle-intellij-plugin limitation: https://github.com/JetBrains/gradle-intellij-plugin/issues/66 -->
+  <!-- Setting version to 15.0.3 and up. https://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+15+143.1821.5+Release+Notes -->
+  <idea-version since-build="143.1821.5" />
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
…5+ (including 16EAP) - temporary workaround

fixes #438 

Temporary workaround for inability to individually control "since" and "until" version attributes in plugin.xml via the gradle-intellij-plugin. Setting the range manually to allow us to cover all versions 15+ in a single release.

updateSinceUntilBuild = false - this prevents the plugin from adding version ranges of its own. Instead it will leave the manually entered ranges as is.

NOTE: this is not a permanent solution. This is temporary until the gradle-intellij-plugin issue referenced in #438 is resolved.

