### PR TITLE
Adding GCP Managed VM "Cloud" support.

### DIFF
--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -119,6 +119,12 @@
       <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.png" removable="false" auto-create-binding="true" can-attach-label="false">
         <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
       </item>
+      <item class="com.google.gct.idea.elysium.ProjectSelector" icon="icons/googleFavicon.png" removable="true" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="0" />
+      </item>
+      <item class="com.intellij.openapi.ui.TextFieldWithBrowseButton" icon="com/intellij/ide/ui/laf/icons/browseButton.png" removable="true" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="0" />
+      </item>
     </group>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,22 @@ release {
     }
 }
 
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // We aren't building or doing anything interesting for release.
 // We just update the version and generate the tag as CI will handle deployment.
 task doRelease {

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <idea-plugin version="2">
   <id>com.google.gct.core</id>
   <name>Google Cloud Tools</name>
@@ -37,6 +53,7 @@ Code inspections for AppEngine Java code.</description>
     <programRunner implementation="com.google.gct.idea.debugger.CloudDebuggerRunner"/>
     <xdebugger.breakpointType implementation="com.google.gct.idea.debugger.CloudLineBreakpointType"/>
     <projectService serviceImplementation="com.google.gct.idea.debugger.CloudDebugProcessStateSerializer"/>
+
     <applicationService serviceInterface="com.google.gct.idea.CloudToolsPluginInfoService"
                         serviceImplementation="com.google.gct.idea.IdeaCloudToolsPluginInfoService"/>
     <applicationService serviceInterface="com.google.gct.idea.CloudToolsPluginConfigurationService"

--- a/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/app.yaml
+++ b/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/app.yaml
@@ -1,0 +1,2 @@
+runtime: custom
+vm: true

--- a/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/jar.dockerfile
+++ b/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/jar.dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/google_appengine/openjdk8
+ADD target.jar /app/
+ENTRYPOINT ["/docker-entrypoint.bash"]
+CMD ["java","-jar","/app/target.jar"]

--- a/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/war.dockerfile
+++ b/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/war.dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/google_appengine/jetty9
+ADD target.war $JETTY_BASE/webapps/root.war

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -16,6 +16,22 @@
 
 select.project.signin=Sign in with your Google account to list your Google Developers Console projects.
 
+cloud.project.label=Project\:
+
+appengine.cloudsdk.location.label=Cloud SDK path\:
+appengine.cloudsdk.location.browse.window.title=Browse to Cloud SDK location
+appengine.appyaml.location.browse.window.title=Browse for Your App.Yaml Location
+appengine.managedvm.name=App Engine Managed VM
+appengine.managedvm.configtype.auto.label=Auto
+appengine.managedvm.configtype.custom.label=Custom
+appengine.managedvm.dockerfile.location.label=Dockerfile path\:
+appengine.managedvm.config.destination.folder.label=Choose destination folder\:
+appengine.managedvm.config.choose.destination.folder.window.title=Choose destination folder
+appengine.managedvm.config.destination.chooser.title=Choose Generated Configuration Destination Folder
+appengine.generate.config.button=Generate...
+appengine.appyaml.location.label=app.yaml path\:
+appengine.dockerfile.location.browse.button=Browse for Your Dockerfile Location
+
 clonefromgcp.projectid=Cloud Project:
 clonefromgcp.title=Clone from Google Cloud
 clonefromgcp.button=Clone
@@ -134,3 +150,4 @@ clouddebug.background.listener.access.error.message=Access denied while listenin
 clouddebug.background.listener.general.error.message=There was an unexpected error while listening for Cloud Debugger snapshots for project <strong>{0}</strong>. Error details: <strong>{1}</strong>
 clouddebug.debug.targets.error=Error accessing debug targets: {0}
 clouddebug.debug.targets.accessdenied=Access denied. You may not have the necessary permissions to run Cloud Debugger with this project.
+

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/CloudToolsPluginInitializationComponent.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/CloudToolsPluginInitializationComponent.java
@@ -15,11 +15,14 @@
  */
 package com.google.gct.idea;
 
+import com.google.gct.idea.appengine.cloud.ManagedVmCloudType;
 import com.google.gct.idea.debugger.CloudDebugConfigType;
 
 import com.intellij.execution.configurations.ConfigurationType;
 import com.intellij.openapi.components.ApplicationComponent;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.remoteServer.ServerType;
+import com.intellij.remoteServer.impl.configuration.deployment.DeployToServerConfigurationType;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -49,6 +52,12 @@ public class CloudToolsPluginInitializationComponent implements ApplicationCompo
       pluginConfigurationService
           .registerExtension(
               ConfigurationType.CONFIGURATION_TYPE_EP, new CloudDebugConfigType());
+    }
+    if (pluginInfoService.shouldEnable(GctFeature.MANAGEDVM)) {
+      ManagedVmCloudType managedVmCloudType = new ManagedVmCloudType();
+      pluginConfigurationService.registerExtension(ServerType.EP_NAME, managedVmCloudType);
+      pluginConfigurationService.registerExtension(ConfigurationType.CONFIGURATION_TYPE_EP,
+          new DeployToServerConfigurationType(managedVmCloudType));
     }
     if (pluginInfoService.shouldEnableErrorFeedbackReporting()) {
       pluginConfigurationService

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/GctFeature.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/GctFeature.java
@@ -28,7 +28,8 @@ import java.util.Set;
  */
 public enum GctFeature implements Feature {
   // DEBUGGER is enabled in IDEA Ultimate and Community, and disabled everywhere else.
-  DEBUGGER(ImmutableSet.of(IntelliJPlatform.IDEA, IntelliJPlatform.IDEA_IC), null, null);
+  DEBUGGER(ImmutableSet.of(IntelliJPlatform.IDEA, IntelliJPlatform.IDEA_IC), null, null),
+  MANAGEDVM(null, "feature.managedvm", "ct4ij.feature.managedvm");
 
   private final Set<IntelliJPlatform> supportedPlatforms;
   private final String resourceFlagName;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineHelper.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.intellij.remoteServer.runtime.deployment.ServerRuntimeInstance.DeploymentOperationCallback;
+import com.intellij.remoteServer.runtime.log.LoggingHandler;
+
+import java.io.File;
+
+/**
+ * Provides basic Gcloud based App Engine functionality for our Cloud Tools plugin.
+ */
+public interface AppEngineHelper {
+
+  /**
+   * The path to the gcloud command on the local file system.
+   */
+  File getGcloudCommandPath();
+
+  /**
+   * The app engine project ID configured for this helper.
+   */
+  String getProjectId();
+
+  /**
+   * The default app.yaml to use.
+   */
+  File defaultAppYaml();
+
+  /**
+   * The default Dockerfile we suggest for custom MVM deployments.
+   *
+   * @param deploymentArtifactType depending on the artifact type we provide a different default
+   *                               Dockerfile
+   * @return A {@link java.io.File} path to the default Dockerfile
+   */
+  File defaultDockerfile(DeploymentArtifactType deploymentArtifactType);
+
+  /**
+   * Creates a {@link Runnable} that will perform custom MVM deployment on {@code run()).
+   *
+   * @param loggingHandler logging messages will be output to this
+   * @param artifactToDeploy the {@link File} path to the Java artifact to be deployed
+   * @param appYamlPath the {@link File} path to the app.yaml to use for deployment
+   * @param dockerfilePath the {@link File} path to the Dockerfile to be used for the custom MVM
+   *                       runtime
+   * @param deploymentCallback a callback for handling successful completion of the operation
+   * @return the runnable that will perform the deployment operation
+   */
+  Runnable createCustomDeploymentOperation(
+      LoggingHandler loggingHandler,
+      File artifactToDeploy,
+      File appYamlPath,
+      File dockerfilePath,
+      DeploymentOperationCallback deploymentCallback);
+
+  /**
+   * Creates a {@link Runnable} that will perform a standard MVM deployment with an automatically
+   * configured runtime (app.yaml and Dockerfile) on {@code run()).
+   *
+   * @param loggingHandler logging messages will be output to this
+   * @param artifactToDeploy the {@link File} path to the Java artifact to be deployed
+   * @param deploymentCallback a callback for handling successful completion of the operation
+   * @return the runnable that will perform the deployment operation
+   */
+  Runnable createAutoDeploymentOperation(
+      LoggingHandler loggingHandler,
+      File artifactToDeploy,
+      DeploymentOperationCallback deploymentCallback);
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.google.common.base.Preconditions;
+
+import com.intellij.remoteServer.runtime.deployment.ServerRuntimeInstance.DeploymentOperationCallback;
+import com.intellij.remoteServer.runtime.log.LoggingHandler;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * A Cloud SDK (gcloud) based implementation of the {@link AppEngineHelper} interface.
+ */
+public class CloudSdkAppEngineHelper implements AppEngineHelper {
+
+  private static final String DEFAUL_APP_YAML_PATH = "/generation/src/appengine/mvm/app.yaml";
+  private static final String DEFAUL_JAR_DOCKERFILE_PATH
+      = "/generation/src/appengine/mvm/jar.dockerfile";
+  private static final String DEFAUL_WAR_DOCKERFILE_PATH
+      = "/generation/src/appengine/mvm/war.dockerfile";
+
+  private final File gcloudCommandPath;
+  private final String projectId;
+
+  public CloudSdkAppEngineHelper(@NotNull File gcloudCommandPath, @NotNull String projectId) {
+    this.gcloudCommandPath = gcloudCommandPath;
+    this.projectId = projectId;
+  }
+
+  @NotNull
+  @Override
+  public File getGcloudCommandPath() {
+    return gcloudCommandPath;
+  }
+
+  @NotNull
+  @Override
+  public String getProjectId() {
+    return projectId;
+  }
+
+  @NotNull
+  @Override
+  public File defaultAppYaml() {
+    return getFileFromResourcePath(DEFAUL_APP_YAML_PATH);
+  }
+
+  @Nullable
+  @Override
+  public File defaultDockerfile(DeploymentArtifactType deploymentArtifactType) {
+    switch (deploymentArtifactType) {
+      case WAR:
+        return getFileFromResourcePath(DEFAUL_WAR_DOCKERFILE_PATH);
+      case JAR:
+        return getFileFromResourcePath(DEFAUL_JAR_DOCKERFILE_PATH);
+      default:
+        return null;
+    }
+  }
+
+  @NotNull
+  @Override
+  public Runnable createCustomDeploymentOperation(LoggingHandler loggingHandler,
+      File artifactToDeploy, File appYamlPath, File dockerfilePath,
+      DeploymentOperationCallback deploymentCallback) {
+    return new DoManagedVmDeployment(
+        this,
+        loggingHandler,
+        artifactToDeploy,
+        appYamlPath,
+        dockerfilePath,
+        deploymentCallback
+    );
+  }
+
+  @NotNull
+  @Override
+  public Runnable createAutoDeploymentOperation(
+      LoggingHandler loggingHandler,
+      File artifactToDeploy,
+      DeploymentOperationCallback deploymentCallback) throws IllegalArgumentException {
+    DeploymentArtifactType artifactType = DeploymentArtifactType.typeForPath(artifactToDeploy);
+    if (artifactType == DeploymentArtifactType.UNKNOWN) {
+      throw new IllegalArgumentException(artifactToDeploy.getPath() + " is not a support artifact "
+          + "type for automatic deployment");
+    }
+    return new DoManagedVmDeployment(
+        this,
+        loggingHandler,
+        artifactToDeploy,
+        defaultAppYaml(),
+        defaultDockerfile(artifactType),
+        deploymentCallback
+    );
+  }
+
+  @NotNull
+  private File getFileFromResourcePath(String resourcePath) {
+    File appYaml;
+    try {
+      URL resource = this.getClass().getClassLoader().getResource(resourcePath);
+      Preconditions
+          .checkArgument(resource != null, resourcePath + " is not a valid resource path.");
+      appYaml = new File(resource.toURI());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    return appYaml;
+  }
+
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/DeploymentArtifactType.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/DeploymentArtifactType.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.Locale;
+
+/**
+ * Represents the supported Java artifact types that we can deploy to App Engine (Managed VMs).
+ */
+public enum DeploymentArtifactType {
+  UNKNOWN, JAR, WAR;
+
+  /**
+   * Returns the right {@code DeploymentArtifactType} for the given {@code deployPackage}.
+   */
+  @NotNull
+  public static DeploymentArtifactType typeForPath(@NotNull File deployPackage) {
+    if (deployPackage.getPath().endsWith(".jar")) {
+      return JAR;
+    } else if (deployPackage.getPath().endsWith(".war")) {
+      return WAR;
+    }
+    return UNKNOWN;
+  }
+
+
+  @Override
+  public String toString() {
+    return "." + name().toLowerCase(Locale.US);
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/DoManagedVmDeployment.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/DoManagedVmDeployment.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.GeneralCommandLine.ParentEnvironmentType;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.remoteServer.runtime.deployment.DeploymentRuntime;
+import com.intellij.remoteServer.runtime.deployment.ServerRuntimeInstance.DeploymentOperationCallback;
+import com.intellij.remoteServer.runtime.log.LoggingHandler;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Performs the deployment of ManagedVM based applications to GCP.
+ */
+class DoManagedVmDeployment implements Runnable {
+
+  private LoggingHandler loggingHandler;
+  private File deploymentArtifactPath;
+  private File appYamlPath;
+  private File dockerFilePath;
+  private AppEngineHelper appEngineHelper;
+  private DeploymentOperationCallback callback;
+  private DeploymentArtifactType artifactType;
+
+  DoManagedVmDeployment(
+      @NotNull AppEngineHelper appEngineHelper,
+      @NotNull LoggingHandler loggingHandler,
+      @NotNull File deploymentArtifactPath,
+      @NotNull File appYamlPath,
+      @NotNull File dockerFilePath,
+      @NotNull DeploymentOperationCallback callback) {
+    this.appEngineHelper = appEngineHelper;
+    this.loggingHandler = loggingHandler;
+    this.deploymentArtifactPath = deploymentArtifactPath;
+    this.callback = callback;
+    this.appYamlPath = appYamlPath;
+    this.dockerFilePath = dockerFilePath;
+    this.artifactType = DeploymentArtifactType.typeForPath(deploymentArtifactPath);
+  }
+
+  public void run() {
+    File stagingDirectory;
+    try {
+      stagingDirectory = FileUtil.createTempDirectory(
+          "gae-mvm" /* prefix */,
+          null /* suffix */,
+          true  /* deleteOnExit */);
+      consoleLogLn(
+          loggingHandler,
+          "Created temporary staging directory: " + stagingDirectory.getAbsolutePath());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    File stagedArtifactPath =
+        copyFile(stagingDirectory, "target" + artifactType, deploymentArtifactPath);
+    stagedArtifactPath.setReadable(true /* readable */, false /* ownerOnly */);
+
+    copyFile(stagingDirectory, "app.yaml", this.appYamlPath);
+    copyFile(stagingDirectory, "Dockerfile", this.dockerFilePath);
+
+    GeneralCommandLine commandLine = new GeneralCommandLine(
+        appEngineHelper.getGcloudCommandPath().getAbsolutePath());
+    commandLine.addParameters("preview", "app", "deploy", "app.yaml", "--promote", "--quiet");
+    commandLine.addParameter("--project=" + appEngineHelper.getProjectId());
+    commandLine.withWorkDirectory(stagingDirectory);
+    consoleLogLn(loggingHandler, "Working directory set to: " + stagingDirectory.getAbsolutePath());
+    commandLine.withParentEnvironmentType(ParentEnvironmentType.CONSOLE);
+    Process process = null;
+    try {
+      consoleLogLn(loggingHandler, "Executing: " + commandLine.getCommandLineString()
+      );
+      process = commandLine.createProcess();
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+    final ProcessHandler processHandler = new OSProcessHandler(process,
+        commandLine.getCommandLineString());
+    loggingHandler.attachToProcess(processHandler);
+    processHandler.addProcessListener(new ProcessAdapter() {
+      @Override
+      public void processTerminated(ProcessEvent event) {
+        if (event.getExitCode() == 0) {
+          callback.succeeded(new DeploymentRuntime() {
+            @Override
+            public boolean isUndeploySupported() {
+              return false;
+            }
+
+            @Override
+            public void undeploy(@NotNull UndeploymentTaskCallback callback) {
+              throw new UnsupportedOperationException();
+            }
+          });
+        } else {
+          callback.errorOccurred("Deployment failed with exit code: " + event.getExitCode());
+        }
+      }
+    });
+    processHandler.startNotify();
+  }
+
+  private File copyFile(File stagingDirectory, String targetFileName, File sourceFilePath) {
+    try {
+      File destinationFilePath = new File(stagingDirectory, targetFileName);
+      FileUtil.copy(sourceFilePath, destinationFilePath);
+      consoleLogLn(loggingHandler, "Copied %s %s to %s", targetFileName,
+          sourceFilePath.getAbsolutePath(), destinationFilePath.getAbsolutePath());
+      return destinationFilePath;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void consoleLogLn(LoggingHandler deploymentLoggingHandler, String message,
+      String... arguments) {
+    deploymentLoggingHandler.print(String.format(message + "\n", (Object[]) arguments));
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurable.form
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurable.form
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.gct.idea.appengine.cloud.ManagedVmCloudConfigurable">
+  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="384" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <vspacer id="e9841">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="f6d93" class="com.google.gct.idea.elysium.ProjectSelector" binding="projectSelector">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="df74a" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="messages/CloudToolsBundle" key="appengine.cloudsdk.location.label"/>
+        </properties>
+      </component>
+      <component id="9625" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="messages/CloudToolsBundle" key="cloud.project.label"/>
+        </properties>
+      </component>
+      <hspacer id="dda7e">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
+      <component id="19d20" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="cloudSdkLocationField">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurable.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurable.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.google.gct.idea.appengine.util.CloudSdkUtil;
+import com.google.gct.idea.elysium.ProjectSelector;
+import com.google.gct.idea.util.GctBundle;
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.openapi.util.Comparing;
+import com.intellij.remoteServer.RemoteServerConfigurable;
+import com.intellij.ui.DocumentAdapter;
+
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.event.DocumentEvent;
+
+/**
+ * GCP ManagedVM Cloud configuration UI.
+ */
+public class ManagedVmCloudConfigurable extends RemoteServerConfigurable implements Configurable {
+
+  private final ManagedVmServerConfiguration configuration;
+  @Nullable
+  private final Project project;
+
+  private String displayName = GctBundle.message("appengine.managedvm.name");
+  private JPanel myMainPanel;
+  private TextFieldWithBrowseButton cloudSdkLocationField;
+  private ProjectSelector projectSelector;
+
+  public ManagedVmCloudConfigurable(ManagedVmServerConfiguration configuration,
+      @Nullable Project project) {
+    this.configuration = configuration;
+    this.project = project;
+
+    String cloudSdkPath = CloudSdkUtil.findCloudSdkPath();
+    if (cloudSdkPath != null && configuration.getCloudSdkPath() == null) {
+      configuration.setCloudSdkPath(cloudSdkPath);
+      cloudSdkLocationField.setText(cloudSdkPath);
+    }
+    cloudSdkLocationField.addBrowseFolderListener(
+        GctBundle.message("appengine.cloudsdk.location.browse.window.title"),
+        null,
+        project,
+        FileChooserDescriptorFactory.createSingleFileDescriptor()
+    );
+    projectSelector.getDocument().addDocumentListener(new DocumentAdapter() {
+      @Override
+      protected void textChanged(DocumentEvent e) {
+        if (projectSelector != null) {
+          displayName = projectSelector.getText() + " Deployment";
+        }
+
+      }
+    });
+
+  }
+
+  @Nls
+  @Override
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  @Nullable
+  @Override
+  public String getHelpTopic() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public JComponent createComponent() {
+    return myMainPanel;
+  }
+
+  @Override
+  public boolean isModified() {
+    return !Comparing.strEqual(getCloudSdkLocation(), configuration.getCloudSdkPath()) ||
+        !Comparing.strEqual(getCloudProjectName(), configuration.getCloudProjectName());
+  }
+
+  @Override
+  public void apply() throws ConfigurationException {
+    configuration.setCloudProjectName(projectSelector.getText());
+    configuration.setCloudSdkPath(cloudSdkLocationField.getText());
+  }
+
+  @Override
+  public void reset() {
+    cloudSdkLocationField.setText(configuration.getCloudSdkPath());
+    projectSelector.setText(configuration.getCloudProjectName());
+  }
+
+  /**
+   * We don't need to test the connection if we know the cloud SDK, user, and project ID are valid.
+   */
+  @Override
+  public boolean canCheckConnection() {
+    return false;
+  }
+
+  public String getCloudSdkLocation() {
+    return cloudSdkLocationField.getText();
+  }
+
+  public String getCloudProjectName() {
+    return projectSelector.getText();
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudType.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudType.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.google.gct.idea.appengine.cloud.ManagedVmDeploymentConfiguration.ConfigType;
+import com.google.gct.idea.ui.GoogleCloudToolsIcons;
+import com.google.gct.idea.util.GctBundle;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import com.intellij.packaging.artifacts.Artifact;
+import com.intellij.packaging.artifacts.ArtifactManager;
+import com.intellij.remoteServer.RemoteServerConfigurable;
+import com.intellij.remoteServer.ServerType;
+import com.intellij.remoteServer.configuration.RemoteServer;
+import com.intellij.remoteServer.configuration.deployment.DeploymentConfigurator;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
+import com.intellij.remoteServer.configuration.deployment.JavaDeploymentSourceUtil;
+import com.intellij.remoteServer.runtime.ServerConnector;
+import com.intellij.remoteServer.runtime.ServerTaskExecutor;
+import com.intellij.remoteServer.runtime.deployment.DeploymentLogManager;
+import com.intellij.remoteServer.runtime.deployment.DeploymentTask;
+import com.intellij.remoteServer.runtime.deployment.ServerRuntimeInstance;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.swing.Icon;
+
+
+/**
+ * This class hooks into IntelliJ's
+ * <a href="https://www.jetbrains.com/idea/help/clouds.html>Cloud</a> configurations for
+ * infrastructure based deployment flows.
+ */
+public class ManagedVmCloudType extends ServerType<ManagedVmServerConfiguration> {
+
+  public ManagedVmCloudType() {
+    super("app-engine-managed-vm");
+  }
+
+  @NotNull
+  @Override
+  public String getPresentableName() {
+    return GctBundle.message("appengine.managedvm.name");
+  }
+
+  @NotNull
+  @Override
+  public Icon getIcon() {
+    return GoogleCloudToolsIcons.APP_ENGINE;
+  }
+
+  @NotNull
+  @Override
+  public ManagedVmServerConfiguration createDefaultConfiguration() {
+    return new ManagedVmServerConfiguration();
+  }
+
+  @NotNull
+  @Override
+  public RemoteServerConfigurable createServerConfigurable(
+      @NotNull ManagedVmServerConfiguration configuration) {
+    return new ManagedVmCloudConfigurable(configuration, null);
+  }
+
+  @NotNull
+  @Override
+  public DeploymentConfigurator<?, ManagedVmServerConfiguration> createDeploymentConfigurator(
+      Project project) {
+    return new ManagedVmDeploymentConfigurator(project);
+  }
+
+  @NotNull
+  @Override
+  public ServerConnector<?> createConnector(@NotNull ManagedVmServerConfiguration configuration,
+      @NotNull ServerTaskExecutor asyncTasksExecutor) {
+    return new ManagedVmServerConnector(configuration);
+  }
+
+  private static class ManagedVmDeploymentConfigurator extends
+      DeploymentConfigurator<ManagedVmDeploymentConfiguration, ManagedVmServerConfiguration> {
+
+    private final Project project;
+
+    public ManagedVmDeploymentConfigurator(Project project) {
+      this.project = project;
+    }
+
+    @NotNull
+    @Override
+    public List<DeploymentSource> getAvailableDeploymentSources() {
+      return JavaDeploymentSourceUtil
+          .getInstance().createArtifactDeploymentSources(project, getJarsAndWars());
+    }
+
+    private List<Artifact> getJarsAndWars() {
+      List<Artifact> jarsAndWars = new ArrayList<Artifact>();
+      for (Artifact artifact : ArtifactManager.getInstance(project).getArtifacts()) {
+        if (artifact.getArtifactType().getId().equalsIgnoreCase("jar")
+            || artifact.getArtifactType().getId().equalsIgnoreCase("war")) {
+          jarsAndWars.add(artifact);
+        }
+      }
+
+      Collections.sort(jarsAndWars, ArtifactManager.ARTIFACT_COMPARATOR);
+      return jarsAndWars;
+    }
+
+    @NotNull
+    @Override
+    public ManagedVmDeploymentConfiguration createDefaultConfiguration(
+        @NotNull DeploymentSource source) {
+      return new ManagedVmDeploymentConfiguration();
+    }
+
+    @Nullable
+    @Override
+    public SettingsEditor<ManagedVmDeploymentConfiguration> createEditor(
+        @NotNull DeploymentSource source,
+        @NotNull RemoteServer<ManagedVmServerConfiguration> server) {
+      return new ManagedVmDeploymentRunConfigurationEditor(project, source,
+          new CloudSdkAppEngineHelper(new File(server.getConfiguration().getCloudSdkPath()),
+              server.getConfiguration().getCloudProjectName()));
+    }
+  }
+
+  private class ManagedVmServerConnector extends ServerConnector<ManagedVmDeploymentConfiguration> {
+
+    private ManagedVmServerConfiguration configuration;
+
+    public ManagedVmServerConnector(
+        ManagedVmServerConfiguration configuration) {
+      this.configuration = configuration;
+    }
+
+    @Override
+    public void connect(@NotNull ConnectionCallback<ManagedVmDeploymentConfiguration> callback) {
+      callback.connected(new ManagedVmRuntimeInstance(configuration));
+    }
+  }
+
+  private static class ManagedVmRuntimeInstance extends
+      ServerRuntimeInstance<ManagedVmDeploymentConfiguration> {
+
+    private ManagedVmServerConfiguration configuration;
+
+    public ManagedVmRuntimeInstance(
+        ManagedVmServerConfiguration configuration) {
+      this.configuration = configuration;
+    }
+
+    @Override
+    public void deploy(@NotNull final DeploymentTask<ManagedVmDeploymentConfiguration> task,
+        @NotNull final DeploymentLogManager logManager,
+        @NotNull final DeploymentOperationCallback callback) {
+      FileDocumentManager.getInstance().saveAllDocuments();
+      AppEngineHelper appEngineHelper = new CloudSdkAppEngineHelper(
+          getFileFromFilePath(configuration.getCloudSdkPath()),
+          configuration.getCloudProjectName()
+      );
+
+
+      final Runnable doDeployment;
+      ManagedVmDeploymentConfiguration deploymentConfig = task.getConfiguration();
+      if (deploymentConfig.getConfigType() == ConfigType.AUTO) {
+        doDeployment = appEngineHelper.createAutoDeploymentOperation(
+            logManager.getMainLoggingHandler(),
+            task.getSource().getFile(),
+            callback
+        );
+      } else {
+        doDeployment = appEngineHelper.createCustomDeploymentOperation(
+            logManager.getMainLoggingHandler(),
+            task.getSource().getFile(),
+            getFileFromFilePath(deploymentConfig.getAppYamlPath()),
+            getFileFromFilePath(deploymentConfig.getDockerFilePath()),
+            callback
+        );
+      }
+      ProgressManager.getInstance()
+          .run(new Task.Backgroundable(task.getProject(), "Deploying to MVM", true,
+              null) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+              ApplicationManager.getApplication().invokeLater(doDeployment);
+            }
+          });
+    }
+
+    @Override
+    public void computeDeployments(@NotNull ComputeDeploymentsCallback callback) {
+    }
+
+    @Override
+    public void disconnect() {
+    }
+
+    @NotNull
+    private File getFileFromFilePath(String filePath) {
+      File file;
+      file = new File(filePath);
+      if (!file.exists()) {
+        throw new RuntimeException(filePath + " does not exist");
+      }
+      return file;
+    }
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentConfiguration.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.google.gct.idea.util.GctBundle;
+
+import com.intellij.remoteServer.util.CloudDeploymentNameConfiguration;
+import com.intellij.util.xmlb.annotations.Attribute;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The model for a Managed VM based deployment configuration.  This state is specific to the
+ * artifact that's being deployed, as such there can be multiple per project.
+ */
+public class ManagedVmDeploymentConfiguration extends
+    CloudDeploymentNameConfiguration<ManagedVmDeploymentConfiguration> {
+
+  public enum ConfigType {
+    AUTO("appengine.managedvm.configtype.auto.label"),
+    CUSTOM("appengine.managedvm.configtype.custom.label");
+
+    private String label;
+
+    ConfigType(String label) {
+      this.label = label;
+    }
+
+    @Override
+    public String toString() {
+      return GctBundle.message(label);
+    }
+  }
+
+  private String dockerFilePath;
+  private String appYamlPath;
+  private ConfigType configType;
+
+  @Attribute("dockerFilePath")
+  public String getDockerFilePath() {
+    return dockerFilePath;
+  }
+
+  @Attribute("appYamlPath")
+  public String getAppYamlPath() {
+    return appYamlPath;
+  }
+
+  @Attribute("configType")
+  public ConfigType getConfigType() {
+    return configType == null ? ConfigType.AUTO : configType;
+  }
+
+  public void setConfigType(@NotNull ConfigType configType) {
+    this.configType = configType;
+  }
+
+  public void setDockerFilePath(String dockerFilePath) {
+    this.dockerFilePath = dockerFilePath;
+  }
+
+  public void setAppYamlPath(String appYamlPath) {
+    this.appYamlPath = appYamlPath;
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentRunConfigurationEditor.form
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentRunConfigurationEditor.form
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.gct.idea.appengine.cloud.ManagedVmDeploymentRunConfigurationEditor">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="551" height="537"/>
+    </constraints>
+    <properties/>
+    <border type="empty" title=""/>
+    <children>
+      <hspacer id="1b35d">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
+      <vspacer id="b83b9">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="85544" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Configuration:"/>
+        </properties>
+      </component>
+      <component id="e42d6" class="javax.swing.JComboBox" binding="configTypeComboBox">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <model/>
+        </properties>
+      </component>
+      <grid id="2f0e9" binding="mvmConfigFilesPanel" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none" title="App Engine  ManagedVM Configuration"/>
+        <children>
+          <component id="d9a0f" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="messages/CloudToolsBundle" key="appengine.appyaml.location.label"/>
+            </properties>
+          </component>
+          <component id="9c515" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="appYamlPathField">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="823cb" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="messages/CloudToolsBundle" key="appengine.managedvm.dockerfile.location.label"/>
+            </properties>
+          </component>
+          <component id="bb46d" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="dockerFilePathField">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="c74c6" class="javax.swing.JButton" binding="generateAppYamlButton">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="messages/CloudToolsBundle" key="appengine.generate.config.button"/>
+            </properties>
+          </component>
+          <component id="10e1e" class="javax.swing.JButton" binding="generateDockerfileButton">
+            <constraints>
+              <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="messages/CloudToolsBundle" key="appengine.generate.config.button"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentRunConfigurationEditor.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.google.common.base.Supplier;
+import com.google.gct.idea.appengine.cloud.ManagedVmDeploymentConfiguration.ConfigType;
+import com.google.gct.idea.util.GctBundle;
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import java.io.IOException;
+
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+/**
+ * Editor for a ManagedVM Deployment runtime configuration.
+ */
+public class ManagedVmDeploymentRunConfigurationEditor extends
+    SettingsEditor<ManagedVmDeploymentConfiguration> {
+
+  private final Project project;
+
+  private JComboBox configTypeComboBox;
+  private JPanel mvmConfigFilesPanel;
+  private JPanel mainPanel;
+  private TextFieldWithBrowseButton appYamlPathField;
+  private TextFieldWithBrowseButton dockerFilePathField;
+  private JButton generateAppYamlButton;
+  private JButton generateDockerfileButton;
+  private AppEngineHelper appEngineHelper;
+
+
+  public ManagedVmDeploymentRunConfigurationEditor(final Project project,
+      final DeploymentSource source, final AppEngineHelper appEngineHelper) {
+    this.project = project;
+    this.appEngineHelper = appEngineHelper;
+    configTypeComboBox.setModel(new DefaultComboBoxModel(ConfigType.values()));
+    configTypeComboBox.setSelectedItem(ConfigType.AUTO);
+    mvmConfigFilesPanel.setVisible(false);
+    configTypeComboBox.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        if (getConfigType() == ConfigType.CUSTOM) {
+          mvmConfigFilesPanel.setVisible(true);
+        } else {
+          mvmConfigFilesPanel.setVisible(false);
+        }
+      }
+    });
+    dockerFilePathField.addBrowseFolderListener(
+        GctBundle.message("appengine.dockerfile.location.browse.button"),
+        null,
+        project,
+        FileChooserDescriptorFactory.createSingleFileDescriptor());
+    appYamlPathField.addBrowseFolderListener(
+        GctBundle.message("appengine.appyaml.location.browse.window.title"),
+        null,
+        project,
+        FileChooserDescriptorFactory.createSingleFileDescriptor());
+    generateAppYamlButton.addActionListener(
+        new GenerateConfigActionListener(project, "app.yaml", new Supplier<File>() {
+          @Override
+          public File get() {
+            return appEngineHelper.defaultAppYaml();
+          }
+        }, appYamlPathField));
+    generateDockerfileButton.addActionListener(
+        new GenerateConfigActionListener(project, "Dockerfile", new Supplier<File>() {
+          @Override
+          public File get() {
+            return appEngineHelper
+                .defaultDockerfile(DeploymentArtifactType.typeForPath(source.getFile()));
+          }
+        }, dockerFilePathField));
+  }
+
+
+  @Override
+  protected void resetEditorFrom(ManagedVmDeploymentConfiguration configuration) {
+    dockerFilePathField.setText(configuration.getDockerFilePath());
+    appYamlPathField.setText(configuration.getAppYamlPath());
+    configTypeComboBox.setSelectedItem(configuration.getConfigType());
+  }
+
+  @Override
+  protected void applyEditorTo(ManagedVmDeploymentConfiguration configuration)
+      throws ConfigurationException {
+    configuration.setDockerFilePath(dockerFilePathField.getText());
+    configuration.setAppYamlPath(appYamlPathField.getText());
+    configuration.setConfigType(getConfigType());
+  }
+
+  @Nullable
+  private ConfigType getConfigType() {
+    int selectedIndex = configTypeComboBox.getSelectedIndex();
+    if (selectedIndex == -1) {
+      return null;
+    }
+    return (ConfigType) configTypeComboBox.getItemAt(selectedIndex);
+  }
+
+  @NotNull
+  @Override
+  protected JComponent createEditor() {
+    return mainPanel;
+  }
+
+  /**
+   * A somewhat generic way of generating a file for a {@link TextFieldWithBrowseButton}.
+   */
+  private class GenerateConfigActionListener implements ActionListener {
+
+    private final Project project;
+    private final String fileName;
+    private final TextFieldWithBrowseButton filePicker;
+    private final Supplier<File> sourceFileProvider;
+
+    public GenerateConfigActionListener(
+        Project project,
+        String fileName,
+        Supplier<File> sourceFileProvider,
+        TextFieldWithBrowseButton filePicker) {
+      this.project = project;
+      this.fileName = fileName;
+      this.sourceFileProvider = sourceFileProvider;
+      this.filePicker = filePicker;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent event) {
+      SelectConfigDestinationFolderDialog destinationFolderDialog = new
+          SelectConfigDestinationFolderDialog(project);
+      if (destinationFolderDialog.showAndGet()) {
+        File destinationFolderPath = destinationFolderDialog.getDestinationFolder();
+        File destinationFilePath = new File(destinationFolderPath, fileName);
+        try {
+          FileUtil.copy(sourceFileProvider.get(), destinationFilePath);
+          LocalFileSystem.getInstance().refreshAndFindFileByIoFile(destinationFilePath);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+        filePicker.setText(destinationFilePath.getPath());
+      }
+    }
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmServerConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmServerConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.intellij.remoteServer.configuration.ServerConfigurationBase;
+import com.intellij.util.xmlb.annotations.Attribute;
+
+/**
+ * Model for the IntelliJ application scoped 'Cloud' configurations.  This is a base configuration
+ * used by Managed VM deployment runtime configurations. It's primarily the bits that can be
+ * re-used across deployments, such as auth and project.
+ */
+public class ManagedVmServerConfiguration extends
+    ServerConfigurationBase<ManagedVmServerConfiguration> {
+
+  private String cloudSdkPath;
+  private String cloudProjectName;
+
+  @Attribute("cloudSdkPath")
+  public String getCloudSdkPath() {
+    return cloudSdkPath;
+  }
+
+  @Attribute("cloudProjectName")
+  public String getCloudProjectName() {
+    return cloudProjectName;
+  }
+
+  public void setCloudSdkPath(String cloudSdkPath) {
+    this.cloudSdkPath = cloudSdkPath;
+  }
+
+  public void setCloudProjectName(String cloudProjectName) {
+    this.cloudProjectName = cloudProjectName;
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/SelectConfigDestinationFolderDialog.form
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/SelectConfigDestinationFolderDialog.form
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.gct.idea.appengine.cloud.SelectConfigDestinationFolderDialog">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="a8d3" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="destinationFolderChooser">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=""/>
+        </properties>
+      </component>
+      <component id="55c5a" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="messages/CloudToolsBundle" key="appengine.managedvm.config.destination.folder.label"/>
+        </properties>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/SelectConfigDestinationFolderDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/SelectConfigDestinationFolderDialog.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.google.gct.idea.util.GctBundle;
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+/**
+ * A widget for selecting a folder in which to generate ManagedVM source files.
+ */
+public class SelectConfigDestinationFolderDialog extends DialogWrapper {
+
+  private JPanel rootPanel;
+  private TextFieldWithBrowseButton destinationFolderChooser;
+
+  public SelectConfigDestinationFolderDialog(@Nullable Project project) {
+    super(project);
+    setTitle(GctBundle.message("appengine.managedvm.config.destination.chooser.title"));
+
+    init();
+    destinationFolderChooser.addBrowseFolderListener(
+        GctBundle.message("appengine.managedvm.config.choose.destination.folder.window.title"),
+        null,
+        project,
+        FileChooserDescriptorFactory.createSingleFolderDescriptor()
+    );
+  }
+
+  @Nullable
+  @Override
+  protected JComponent createCenterPanel() {
+    return rootPanel;
+  }
+
+  public File getDestinationFolder() {
+    return new File(destinationFolderChooser.getText());
+  }
+
+  @Override
+  protected void doOKAction() {
+
+    super.doOKAction();
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/CloudSdkUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/CloudSdkUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.util;
+
+import com.intellij.execution.configurations.PathEnvironmentVariableUtil;
+import com.intellij.openapi.util.SystemInfo;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+
+/**
+ * Handy Cloud SDK utility methods.
+ *
+ * Not for instantiation.
+ */
+public final class CloudSdkUtil {
+
+  private CloudSdkUtil() {
+    // Not designed for instantiation.
+  }
+  private static final String UNIX_COMMAND = "gcloud";
+  private static final String WIN_COMMAND = "gcloud.cmd";
+
+  /**
+   * Finds the Cloud SDK path on the local file system.
+   *
+   * @return a {@link String} path to the Cloud SDK or {@code null} if it could not be found.
+   */
+  @Nullable
+  public static String findCloudSdkPath() {
+    File gcloudPath = PathEnvironmentVariableUtil
+        .findInPath(SystemInfo.isWindows ? WIN_COMMAND : UNIX_COMMAND);
+    if (gcloudPath != null) {
+      return gcloudPath.getAbsolutePath();
+    }
+    return null;
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudDebugRunConfigurationPanel.form
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudDebugRunConfigurationPanel.form
@@ -10,14 +10,6 @@
     </properties>
     <border type="none"/>
     <children>
-      <component id="b23a6" class="com.intellij.ui.components.JBLabel">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Project:"/>
-        </properties>
-      </component>
       <component id="30c54" class="com.google.gct.idea.elysium.ProjectSelector" binding="myElysiumProjectId">
         <constraints>
           <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -34,6 +26,14 @@
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
+      <component id="b23a6" class="com.intellij.ui.components.JBLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Project:"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/CloudToolsPluginInitializationComponentTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/CloudToolsPluginInitializationComponentTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.gct.idea.appengine.cloud.ManagedVmCloudType;
 import com.google.gct.idea.debugger.CloudDebugConfigType;
 import com.google.gct.idea.testing.BasePluginTestCase;
 
@@ -54,6 +55,24 @@ public class CloudToolsPluginInitializationComponentTest extends BasePluginTestC
     verify(pluginConfigurationService, never())
         .registerExtension(isA(ExtensionPointName.class),
             isA(CloudDebugConfigType.class));
+  }
+
+  @Test
+  public void testInitComponent_managedVmIsEnabled() {
+    when(pluginInfoService.shouldEnable(GctFeature.MANAGEDVM)).thenReturn(true);
+    testComponent.initComponent();
+    verify(pluginConfigurationService).registerExtension(isA(ExtensionPointName.class),
+        isA(ManagedVmCloudType.class));
+  }
+
+
+  @Test
+  public void testInitComponent_managedVmIsDisabled() {
+    when(pluginInfoService.shouldEnable(GctFeature.DEBUGGER)).thenReturn(false);
+    testComponent.initComponent();
+    verify(pluginConfigurationService, never())
+        .registerExtension(isA(ExtensionPointName.class),
+            isA(ManagedVmCloudType.class));
   }
 
   @Test

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/cloud/DeploymentArtifactTypeTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/cloud/DeploymentArtifactTypeTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * Test cases for {@link DeploymentArtifactType}.
+ */
+public class DeploymentArtifactTypeTest {
+
+  @Test
+  public void testTypeForPath_jar() throws Exception {
+    assertEquals(DeploymentArtifactType.JAR,
+        DeploymentArtifactType.typeForPath(new File("/some/path/to/a.jar")));
+  }
+
+  @Test
+  public void testTypeForPath_war() throws Exception {
+    assertEquals(DeploymentArtifactType.WAR,
+        DeploymentArtifactType.typeForPath(new File("/some/path/to/a.war")));
+  }
+
+  @Test
+  public void testTypeForPath_anythingElse() throws Exception {
+    assertEquals(DeploymentArtifactType.UNKNOWN,
+        DeploymentArtifactType.typeForPath(new File("/some/path/to/a.txt")));
+  }
+}


### PR DESCRIPTION
 This is the minimum set of functionality and needs to be augmented with:

1) validation
2) arbitrary war jar artifacts (i.e. the user can pick a jar or war in the file system rather than an artifact, or the user can create an artifact from an existing jar or war)
3) the destination tmp dir for staging needs to be in the git project for correct src context generation
4) currently points at gcloud path rather than cloud sdk root.
5) probably need a more obvious UI hint that files have been created when the user 'generates' their config.
6) tests?
7) Ideally we can update our config generation to use gcloud app gen-config
 managed_vm_cloud_config
 8) Ability to stop the remote service (using gcloud preview app stop
 9) A clear message on the GCP MVM Cloud Type that this costs money and does not scale to 0.
10) finally needs to use plugin's auth credentials instead of gcloud. This depends on a change on the gcloud cli side. 

 I'd like to check this in now that it's feature flag protected so Etan can iterate on it while I'm on paternity.