### PR TITLE
handling and validation of the Cloud SDK path for managed vm config and deployment

### DIFF
--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -124,6 +124,10 @@ Code inspections for AppEngine Java code.</description>
     <applicationService serviceImplementation="com.google.gct.idea.debugger.CloudDebugProcessStateCollector" />
   </extensions>
 
+  <extensions defaultExtensionNs="com.intellij">
+    <applicationService serviceImplementation="com.google.gct.idea.util.SystemEnvironmentProvider" />
+  </extensions>
+
   <actions>
     <action id="AddSnapshotLocation" class="com.google.gct.idea.debugger.actions.ToggleSnapshotLocationAction"/>
 

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -18,8 +18,9 @@ select.project.signin=Sign in with your Google account to list your Google Devel
 
 cloud.project.label=Project\:
 
-appengine.cloudsdk.location.label=Cloud SDK path\:
-appengine.cloudsdk.location.browse.window.title=Browse to Cloud SDK location
+appengine.cloudsdk.location.label=Cloud SDK directory\:
+appengine.cloudsdk.location.browse.window.title=Browse to Cloud SDK directory
+appengine.cloudsdk.location.warning.message=Please select a Cloud SDK directory.
 appengine.appyaml.location.browse.window.title=Browse for Your App.Yaml Location
 appengine.managedvm.name=App Engine Managed VM
 appengine.managedvm.configtype.auto.label=Auto

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurable.form
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurable.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.gct.idea.appengine.cloud.ManagedVmCloudConfigurable">
-  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="384" height="400"/>
@@ -8,11 +8,6 @@
     <properties/>
     <border type="none"/>
     <children>
-      <vspacer id="e9841">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </vspacer>
       <component id="f6d93" class="com.google.gct.idea.elysium.ProjectSelector" binding="projectSelector">
         <constraints>
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -35,17 +30,31 @@
           <text resource-bundle="messages/CloudToolsBundle" key="cloud.project.label"/>
         </properties>
       </component>
-      <hspacer id="dda7e">
-        <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </hspacer>
-      <component id="19d20" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="cloudSdkLocationField">
+      <component id="19d20" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="cloudSdkDirectoryField">
         <constraints>
           <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
+      <vspacer id="e9841">
+        <constraints>
+          <grid row="2" column="0" row-span="2" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="aefe0" class="javax.swing.JLabel" binding="warningMessage">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <foreground color="-65536"/>
+          <text value="Label"/>
+        </properties>
+      </component>
+      <vspacer id="5a971">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmServerConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmServerConfiguration.java
@@ -27,12 +27,12 @@ import com.intellij.util.xmlb.annotations.Attribute;
 public class ManagedVmServerConfiguration extends
     ServerConfigurationBase<ManagedVmServerConfiguration> {
 
-  private String cloudSdkPath;
+  private String cloudSdkExecutablePath;
   private String cloudProjectName;
 
-  @Attribute("cloudSdkPath")
-  public String getCloudSdkPath() {
-    return cloudSdkPath;
+  @Attribute("cloudSdkExecutablePath")
+  public String getCloudSdkExecutablePath() {
+    return cloudSdkExecutablePath;
   }
 
   @Attribute("cloudProjectName")
@@ -40,8 +40,8 @@ public class ManagedVmServerConfiguration extends
     return cloudProjectName;
   }
 
-  public void setCloudSdkPath(String cloudSdkPath) {
-    this.cloudSdkPath = cloudSdkPath;
+  public void setCloudSdkExecutablePath(String cloudSdkExecutablePath) {
+    this.cloudSdkExecutablePath = cloudSdkExecutablePath;
   }
 
   public void setCloudProjectName(String cloudProjectName) {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/util/SystemEnvironmentProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/util/SystemEnvironmentProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.util;
+
+import com.intellij.execution.configurations.PathEnvironmentVariableUtil;
+import com.intellij.openapi.components.ServiceManager;
+
+import java.io.File;
+
+public class SystemEnvironmentProvider {
+
+  public static SystemEnvironmentProvider getInstance() {
+    return ServiceManager.getService(SystemEnvironmentProvider.class);
+  }
+
+  public File findInPath(String fileName) {
+    return PathEnvironmentVariableUtil.findInPath(fileName);
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurableTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurableTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.gct.idea.util.SystemEnvironmentProvider;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.testFramework.PlatformTestCase;
+
+import org.picocontainer.MutablePicoContainer;
+
+import java.io.File;
+
+import javax.swing.JLabel;
+
+public class ManagedVmCloudConfigurableTest extends PlatformTestCase {
+  private SystemEnvironmentProvider environmentProvider;
+  private JLabel warningMessage;
+  private TextFieldWithBrowseButton cloudSdkDirectoryField;
+
+  private static final String CLOUD_SDK_EXECUTABLE_PATH = "/a/b/c/gcloud";
+  private static final String CLOUD_SDK_DIR_PATH = "/a/b/c";
+
+  private static final String INVALID_SDK_DIR_WARNING = "Please select a Cloud SDK directory.";
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    MutablePicoContainer applicationContainer = (MutablePicoContainer)
+        ApplicationManager.getApplication().getPicoContainer();
+
+    environmentProvider = mock(SystemEnvironmentProvider.class);
+
+    applicationContainer.unregisterComponent(SystemEnvironmentProvider.class.getName());
+    applicationContainer.registerComponentInstance(SystemEnvironmentProvider.class.getName(), environmentProvider);
+  }
+
+  public void testSetupWithoutSdkInPath() {
+    when(environmentProvider.findInPath(anyString())).thenReturn(null);
+    initCloudConfigurable();
+
+    assertFalse(warningMessage.isVisible());
+    assertEmpty(cloudSdkDirectoryField.getText());
+  }
+
+  public void testSetupWithSdkInPath() {
+    when(environmentProvider.findInPath(anyString()))
+        .thenReturn(new File(CLOUD_SDK_EXECUTABLE_PATH));
+    initCloudConfigurable();
+
+    assertFalse(warningMessage.isVisible());
+    assertEquals(CLOUD_SDK_DIR_PATH, cloudSdkDirectoryField.getText());
+  }
+
+  public void testSetupWithInvalidSdk() {
+    initCloudConfigurable();
+
+    // Simulating user choosing (or manually typing) an invalid path in the field
+    cloudSdkDirectoryField.setText("/some/invalid/path");
+
+    assertTrue(warningMessage.isVisible());
+    assertEquals(INVALID_SDK_DIR_WARNING, warningMessage.getText());
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+  }
+
+  private void initCloudConfigurable() {
+    ManagedVmCloudConfigurable managedVmCloudConfigurable =
+        new ManagedVmCloudConfigurable(new ManagedVmServerConfiguration(), getProject());
+    warningMessage = managedVmCloudConfigurable.getWarningMessage();
+    cloudSdkDirectoryField = managedVmCloudConfigurable.getCloudSdkDirectoryField();
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/util/CloudSdkUtilTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/util/CloudSdkUtilTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.google.gct.idea.testing.BasePluginTestCase;
+import com.google.gct.idea.util.SystemEnvironmentProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloudSdkUtilTest extends BasePluginTestCase {
+
+  @Mock
+  private SystemEnvironmentProvider environmentProvider;
+
+  private static final String CLOUD_SDK_EXECUTABLE_PATH = "/a/b/c/gcloud";
+  private static final String CLOUD_SDK_DIR_PATH = "/a/b/c";
+
+  @Before
+  public void setUp() {
+    registerService(SystemEnvironmentProvider.class, environmentProvider);
+  }
+
+  @Test
+  public void testPaths() {
+    when(environmentProvider.findInPath(anyString()))
+        .thenReturn(new File(CLOUD_SDK_EXECUTABLE_PATH));
+
+    assertEquals(CLOUD_SDK_EXECUTABLE_PATH,
+        CloudSdkUtil.findCloudSdkExecutablePath(environmentProvider));
+    assertEquals(CLOUD_SDK_DIR_PATH,
+        CloudSdkUtil.findCloudSdkDirectoryPath(environmentProvider));
+  }
+
+  @Test
+  public void testNullPaths() {
+    when(environmentProvider.findInPath(anyString()))
+        .thenReturn(null);
+
+    assertEquals(null, CloudSdkUtil.findCloudSdkExecutablePath(environmentProvider));
+    assertEquals(null, CloudSdkUtil.findCloudSdkDirectoryPath(environmentProvider));
+  }
+
+  @Test
+  public void testDirExecutableConversion() {
+    assertEquals(CLOUD_SDK_EXECUTABLE_PATH,
+        CloudSdkUtil.toExecutablePath(CLOUD_SDK_DIR_PATH));
+    assertEquals(CLOUD_SDK_DIR_PATH,
+        CloudSdkUtil.toParentDirectory(CLOUD_SDK_EXECUTABLE_PATH));
+  }
+}


### PR DESCRIPTION
Fixes #448 

- Validation for SDK path
- Updating to require user to select sdk directory, instead of binary
- Preventing deploy and showing warning message if user attempts to connect / deploy to the managed vm without a valid SDK configured

There are still a couple cleanup todo's related to unit testing.