### PR TITLE
Fix a reference to a mutable Array to be immutable

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/elysium/ProjectSelectorLoadingItem.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/elysium/ProjectSelectorLoadingItem.java
@@ -59,7 +59,7 @@ class ProjectSelectorLoadingItem extends JPanel {
   // This is called to animate the spinner.  It snaps a frame of the spinner based on current timer ticks.
   public void snap() {
     long currentMilliseconds = System.nanoTime() / 1000000;
-    int frame = (int)(currentMilliseconds / 100) % GoogleCloudToolsIcons.STEP_ICONS.length;
-    myProgressIcon.setIcon(GoogleCloudToolsIcons.STEP_ICONS[frame]);
+    int frame = (int)(currentMilliseconds / 100) % GoogleCloudToolsIcons.STEP_ICONS.size();
+    myProgressIcon.setIcon(GoogleCloudToolsIcons.STEP_ICONS.get(frame));
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/ui/GoogleCloudToolsIcons.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/ui/GoogleCloudToolsIcons.java
@@ -17,6 +17,10 @@ package com.google.gct.idea.ui;
 
 import com.intellij.openapi.util.IconLoader;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import javax.swing.Icon;
 
 /**
@@ -31,7 +35,7 @@ public final class GoogleCloudToolsIcons {
   public static final Icon CLOUD= load("/icons/cloudPlatform.png");
   public static final Icon CLOUD_MODULE = load("/icons/google_cloud_module.png");
   public static final Icon REFRESH = load("/icons/refresh.png");
-  public static final Icon[] STEP_ICONS = findStepIcons("/icons/step_");
+  public static final List<Icon> STEP_ICONS = findStepIcons("/icons/step_");
   public static final Icon ENDPOINTS_CARD = load("/icons/background_endpoints.png");
   public static final Icon SERVLET_CARD = load("/icons/background_servlet.png");
   public static final Icon GCM_CARD = load("/icons/background_gcm.png");
@@ -48,12 +52,12 @@ public final class GoogleCloudToolsIcons {
     return IconLoader.getIcon(path, GoogleCloudToolsIcons.class);
   }
 
-  private static Icon[] findStepIcons(String prefix) {
-    Icon[] icons = new Icon[STEPS_COUNT];
+  private static List<Icon> findStepIcons(String prefix) {
+    List<Icon> icons = new ArrayList(STEPS_COUNT);
     for (int i = 0; i < STEPS_COUNT; i++) {
-      icons[i] = IconLoader.getIcon(prefix + (i + 1) + ".png");
+      icons.add(IconLoader.getIcon(prefix + (i + 1) + ".png"));
     }
-    return icons;
+    return Collections.unmodifiableList(icons);
   }
 
   private GoogleCloudToolsIcons() {


### PR DESCRIPTION
This pull request addresses one of FindBugs issues: MS_MUTABLE_ARRAY. Reportedly, the issue is that a public final static field STEP_ICONS is a reference to a mutable array. This fix makes STEP_ICONS a reference to an immutable list.

Note: I am learning Java and Java practices now. I am also trying to familiarize myself with the GitHub workflow for making contributions to this repo by addressing issues reported by FindBugs. Therefore, any kind of feedback is more than welcome.