### PR TITLE
Make inner classes static as suggested by FindBugs

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudType.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudType.java
@@ -150,7 +150,8 @@ public class ManagedVmCloudType extends ServerType<ManagedVmServerConfiguration>
     }
   }
 
-  private class ManagedVmServerConnector extends ServerConnector<ManagedVmDeploymentConfiguration> {
+  private static class ManagedVmServerConnector extends
+      ServerConnector<ManagedVmDeploymentConfiguration> {
 
     private ManagedVmServerConfiguration configuration;
 
@@ -169,7 +170,6 @@ public class ManagedVmCloudType extends ServerType<ManagedVmServerConfiguration>
         // TODO Consider auto opening configuration panel
       }
     }
-
   }
 
   private static class ManagedVmRuntimeInstance extends

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentRunConfigurationEditor.java
@@ -139,7 +139,7 @@ public class ManagedVmDeploymentRunConfigurationEditor extends
   /**
    * A somewhat generic way of generating a file for a {@link TextFieldWithBrowseButton}.
    */
-  private class GenerateConfigActionListener implements ActionListener {
+  private static class GenerateConfigActionListener implements ActionListener {
 
     private final Project project;
     private final String fileName;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/InvalidParameterAnnotationsInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/InvalidParameterAnnotationsInspection.java
@@ -149,7 +149,7 @@ public class InvalidParameterAnnotationsInspection extends EndpointInspectionBas
   /**
    * Quick fix for {@link InvalidParameterAnnotationsInspection} problems.
    */
-  public class MyQuickFix implements LocalQuickFix {
+  public static class MyQuickFix implements LocalQuickFix {
     public MyQuickFix() {
 
     }

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/validation/InvalidParameterAnnotationsInspectionTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/validation/InvalidParameterAnnotationsInspectionTest.java
@@ -137,7 +137,7 @@ public class InvalidParameterAnnotationsInspectionTest extends EndpointTestBase 
   }
 
   private void runQuickFixTest(PsiParameter parameter, String expectedString) {
-    InvalidParameterAnnotationsInspection.MyQuickFix myQuickFix = new InvalidParameterAnnotationsInspection().new MyQuickFix();
+    InvalidParameterAnnotationsInspection.MyQuickFix myQuickFix = new InvalidParameterAnnotationsInspection.MyQuickFix();
     MockProblemDescriptor problemDescriptor = new MockProblemDescriptor(parameter, "", ProblemHighlightType.ERROR);
     myQuickFix.applyFix(myFixture.getProject(), problemDescriptor);
     Assert.assertEquals(expectedString, parameter.getText());


### PR DESCRIPTION
This pull request addresses one of FindBugs issues: SIC_INNER_SHOULD_BE_STATIC. Inner classes do not use the embedded reference to their outer classes, so no need to be non-static. A test case is also fixed according to the these changes.

Note: I am learning Java and Java practices now. I am also trying to familiarize myself with the GitHub workflow for making contributions to this repo by addressing issues reported by FindBugs. Any kind of feedback is more than welcome.