### PR TITLE
Suppress benign FindBugs warning DM_STRING_CTOR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ subprojects {
             exclude group: 'org.hamcrest', module: 'hamcrest-core'
         }
         testCompile 'org.hamcrest:hamcrest-all:1.3'
+        compile 'com.google.code.findbugs:annotations:3.0.1'
     }
 
     apply plugin: 'findbugs'
@@ -70,7 +71,7 @@ subprojects {
         ignoreFailures = true
         sourceSets = [sourceSets.main]
         effort = "max"
-        toolVersion = '2.0.3'
+        toolVersion = '3.0.1'
     }
 
     tasks.withType(FindBugs) {

--- a/common-lib/src/main/java/com/google/gct/idea/feedback/GoogleFeedbackErrorReporter.java
+++ b/common-lib/src/main/java/com/google/gct/idea/feedback/GoogleFeedbackErrorReporter.java
@@ -30,6 +30,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.util.Consumer;
 import com.intellij.util.SystemProperties;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -109,6 +111,7 @@ public class GoogleFeedbackErrorReporter extends ErrorReportSubmitter {
 
     Consumer<String> successCallback = new Consumer<String>() {
       @Override
+      @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
       public void consume(String token) {
         final SubmittedReportInfo reportInfo = new SubmittedReportInfo(
             null, "Issue " + token, SubmittedReportInfo.SubmissionStatus.NEW_ISSUE);

--- a/common-lib/src/main/java/com/google/gct/idea/flags/PropertiesFileFlagReader.java
+++ b/common-lib/src/main/java/com/google/gct/idea/flags/PropertiesFileFlagReader.java
@@ -4,6 +4,8 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.intellij.openapi.diagnostic.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -25,6 +27,7 @@ public class PropertiesFileFlagReader implements FlagReader {
   }
 
   @VisibleForTesting
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   protected PropertiesFileFlagReader(String propertiesFilePath) {
     properties = new Properties();
     InputStream in = null;

--- a/common-test-lib/src/main/java/com/google/gct/idea/testing/TestUtils.java
+++ b/common-test-lib/src/main/java/com/google/gct/idea/testing/TestUtils.java
@@ -19,6 +19,8 @@ import com.intellij.openapi.vfs.encoding.EncodingManager;
 import com.intellij.openapi.vfs.encoding.EncodingManagerImpl;
 import com.intellij.util.pico.DefaultPicoContainer;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.mockito.Mockito;
@@ -127,6 +129,7 @@ public class TestUtils {
     return new MockProject(container, getParentDisposableForCleanup());
   }
 
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   public static void assertIsSerializable(@NotNull Serializable object) {
     ObjectOutputStream out = null;
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/DeploymentArtifactType.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/DeploymentArtifactType.java
@@ -16,6 +16,8 @@
 
 package com.google.gct.idea.appengine.cloud;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -42,6 +44,7 @@ public enum DeploymentArtifactType {
 
 
   @Override
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   public String toString() {
     return "." + name().toLowerCase(Locale.US);
   }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/DoManagedVmDeployment.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/DoManagedVmDeployment.java
@@ -28,6 +28,8 @@ import com.intellij.remoteServer.runtime.deployment.DeploymentRuntime;
 import com.intellij.remoteServer.runtime.deployment.ServerRuntimeInstance.DeploymentOperationCallback;
 import com.intellij.remoteServer.runtime.log.LoggingHandler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -62,6 +64,7 @@ class DoManagedVmDeployment implements Runnable {
     this.artifactType = DeploymentArtifactType.typeForPath(deploymentArtifactPath);
   }
 
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   public void run() {
     File stagingDirectory;
     try {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNameInspection.java
@@ -37,6 +37,8 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiUtilBase;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -163,6 +165,7 @@ public class ApiNameInspection extends EndpointInspectionBase {
     }
 
     @VisibleForTesting
+    @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
     public String getNameSuggestions(String baseString) {
       if(baseString.isEmpty()) {
         return DEFAULT_API_NAME;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiParameterInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiParameterInspection.java
@@ -24,6 +24,9 @@ import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -58,6 +61,7 @@ public class ApiParameterInspection extends EndpointInspectionBase {
   public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
     return new EndpointPsiElementVisitor() {
       @Override
+      @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
       public void visitParameter(PsiParameter psiParameter){
         if (!EndpointUtilities.isEndpointClass(psiParameter)) {
           return;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/EndpointInspectionBase.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/EndpointInspectionBase.java
@@ -22,6 +22,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiInvalidElementAccessException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * The base class for all endpoint inspections.
  */
@@ -34,6 +36,7 @@ public class EndpointInspectionBase extends LocalInspectionTool {
     return "Google Cloud Platform";
   }
 
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   public Project getProject(PsiElement element ) {
     Project project;
     try {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/MethodParameterTypeInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/MethodParameterTypeInspection.java
@@ -22,6 +22,9 @@ import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -108,6 +111,7 @@ public class MethodParameterTypeInspection extends EndpointInspectionBase {
   public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
     return new EndpointPsiElementVisitor() {
       @Override
+      @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
       public void visitParameter (PsiParameter psiParameter){
         if (!EndpointUtilities.isEndpointClass(psiParameter)) {
           return;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/MethodReturnTypeInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/MethodReturnTypeInspection.java
@@ -27,6 +27,8 @@ import com.intellij.psi.PsiInvalidElementAccessException;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiType;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -59,6 +61,7 @@ public class MethodReturnTypeInspection extends EndpointInspectionBase{
   public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
     return new EndpointPsiElementVisitor() {
       @Override
+      @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
       public void visitMethod(PsiMethod method) {
         if (!EndpointUtilities.isEndpointClass(method)) {
           return;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ResourceParameterInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ResourceParameterInspection.java
@@ -33,6 +33,9 @@ import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.PsiParameter;
 import com.intellij.psi.PsiType;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -69,6 +72,7 @@ public class ResourceParameterInspection extends EndpointInspectionBase {
       private int resourceParameterCount = 0;
 
       @Override
+      @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
       public void visitMethod(PsiMethod method) {
         if (!EndpointUtilities.isEndpointClass(method)) {
           return;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/RestSignatureInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/RestSignatureInspection.java
@@ -26,6 +26,9 @@ import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -359,6 +362,7 @@ public class RestSignatureInspection extends EndpointInspectionBase {
    * @param psiMethod the method whose default path is to be determined
    * @return the default path for psiMethod
    */
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   private String getDefaultPath(PsiMethod psiMethod) {
     // Get path from @ApiClass or @Api's resource attribute if it exists
     String apiDefaultResource = getResourceProperty(psiMethod);
@@ -517,6 +521,7 @@ public class RestSignatureInspection extends EndpointInspectionBase {
    * Returns the project associated with {@code method} or null if it cannot retrieve the project.
    */
   @Nullable
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   private static Project getProject(PsiMethod method) {
     Project project;
     try {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/BreakpointUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/BreakpointUtil.java
@@ -21,6 +21,8 @@ import com.google.gct.idea.util.GctBundle;
 
 import com.intellij.openapi.diagnostic.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nullable;
 
 import java.text.ParseException;
@@ -51,6 +53,7 @@ public class BreakpointUtil {
   }
 
   @Nullable
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   public static String getUserMessage(@Nullable StatusMessage statusMessage) {
     if (statusMessage != null && statusMessage.getDescription() != null) {
       String formatString = statusMessage.getDescription().getFormat();
@@ -68,6 +71,7 @@ public class BreakpointUtil {
   }
 
   @Nullable
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   public static Date parseDateTime(@Nullable String dateString) {
     if (dateString == null) {
       return null;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudBreakpointHandler.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudBreakpointHandler.java
@@ -39,6 +39,8 @@ import com.intellij.xdebugger.breakpoints.XBreakpointHandler;
 import com.intellij.xdebugger.breakpoints.XBreakpointManager;
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -98,6 +100,7 @@ public class CloudBreakpointHandler
    *     it will register with the server.
    * </ul>
    */
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   public void cloneToNewBreakpoints(@NotNull final List<Breakpoint> serverBreakpoints) {
     for (Breakpoint serverBreakpoint : serverBreakpoints) {
       if (serverBreakpoint.getIsFinalState() != Boolean.TRUE) {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
@@ -63,6 +63,8 @@ import com.intellij.xdebugger.frame.XExecutionStack;
 import com.intellij.xdebugger.frame.XSuspendContext;
 import com.intellij.xdebugger.ui.XDebugTabLayouter;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -311,6 +313,7 @@ public class CloudDebugProcess extends XDebugProcess implements CloudBreakpointL
           }
 
           @Override
+          @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
           public void onError(String errorMessage) {
             LOG.warn("Could not navigate to breakpoint:" + errorMessage);
           }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
@@ -26,6 +26,9 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.HashSet;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -90,6 +93,7 @@ public class CloudDebugProcessStateController {
 
     Runnable performDelete = new Runnable() {
       @Override
+      @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
       public void run() {
         try {
           client.debuggees().breakpoints().delete(debuggeeId, breakpointId).execute();

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
@@ -39,6 +39,8 @@ import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -276,6 +278,7 @@ public class CloudAttachDialog extends DialogWrapper {
   /**
    * Checks whether a stash or sync is needed based on the chosen target and local state.
    */
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   private void checkSyncStashState() {
     if (processResultState == null) {
       LOG.error("unexpected result state during a check sync stash state");

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/DebugTarget.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/DebugTarget.java
@@ -22,6 +22,8 @@ import com.google.gct.idea.util.GctBundle;
 
 import com.intellij.openapi.diagnostic.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
@@ -41,6 +43,7 @@ class DebugTarget implements DebugTargetSelectorItem {
   private String module;
   private String version;
 
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   public DebugTarget(@NotNull Debuggee debuggee, @NotNull String projectName) {
     this.debuggee = debuggee;
     if (this.debuggee.getLabels() != null) {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/elysium/GoogleUserModelItem.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/elysium/GoogleUserModelItem.java
@@ -29,6 +29,8 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.Image;
@@ -127,6 +129,7 @@ class GoogleUserModelItem extends DefaultMutableTreeNode {
   private void loadErrorState(@NotNull final String errorMessage) {
     SwingUtilities.invokeLater(new Runnable() {
       @Override
+      @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
       public void run() {
         GoogleUserModelItem.this.removeAllChildren();
         GoogleUserModelItem.this.add(new ElysiumErrorModelItem("Error: " + errorMessage));
@@ -135,6 +138,7 @@ class GoogleUserModelItem extends DefaultMutableTreeNode {
     });
   }
 
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   private void loadUserProjects() {
     final List<DefaultMutableTreeNode> result = new ArrayList<DefaultMutableTreeNode>();
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/git/GcpHttpAuthDataProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/git/GcpHttpAuthDataProvider.java
@@ -32,6 +32,9 @@ import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.wm.ex.WindowManagerEx;
 import com.intellij.util.AuthData;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import git4idea.DialogManager;
 import git4idea.remote.GitHttpAuthDataProvider;
 import git4idea.repo.GitRemote;
@@ -58,6 +61,7 @@ public class GcpHttpAuthDataProvider implements GitHttpAuthDataProvider {
 
   @Nullable
   @Override
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   public AuthData getAuthData(@NotNull String url) {
     final Project currentProject = getCurrentProject();
     if ((currentProject != null || Context.ourCurrentContext != null) && isUrlGCP(url)) {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/git/UploadSourceAction.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/git/UploadSourceAction.java
@@ -52,6 +52,8 @@ import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.HashSet;
 import com.intellij.vcsUtil.VcsFileUtil;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -277,6 +279,7 @@ public class UploadSourceAction extends DumbAwareAction {
     return true;
   }
 
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   private static boolean createEmptyGitRepository(@NotNull final Project project,
                                                   @NotNull VirtualFile root,
                                                   @NotNull ProgressIndicator indicator) {
@@ -393,6 +396,7 @@ public class UploadSourceAction extends DumbAwareAction {
     }
   }
 
+  @SuppressFBWarnings(value="DM_STRING_CTOR", justification="Warning due to string concatenation")
   private static void removeGitRemote(final @NotNull Project project, @NotNull GitRepository repository, @NotNull String remote) {
     final GitSimpleHandler handler = new GitSimpleHandler(project, repository.getRoot(), GitCommand.REMOTE);
     handler.setSilent(true);


### PR DESCRIPTION
Fixes a subset of #241. Suppresses FindBugs complaining about calling the String() constructor. All the warnings are due to strings being concatenated with "+".

Adds a FindBugs dependency in build.gradle too (using 'compile' instead of 'testCompile' as the latter doesn't seem to work). Uses version 3.0.1.

No DM_STRING_CTOR at all from now on for all the projects. One minor concern is that an annotation applies to an entire method. (No finer granularity is possible when using annotations.)