### PR TITLE
Updated contributor instructions to read style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,19 +66,20 @@ Other useful targets while developing include:
 ## Contributing code
 
 1. First, please [sign either individual or corporate contributor license agreement](https://cla.developers.google.com/), whichever is applicable.
-2. Set your git user.email property to the address used for step 1. E.g.
+1. Set your git user.email property to the address used for step 1. E.g.
    ```
    git config --global user.email "janedoe@google.com"
    ```
    If you're a Googler or other corporate contributor, 
-   use your corporate email address here, not your personal address. 
-3. Fork the repository into your own Github account.
-4. Please include unit tests for all new code. (Yes, we know not all 
+   use your corporate email address here, not your personal address.
+1. Read the [Google Java Style Guide](http://google.github.io/styleguide/javaguide.html)
+1. Fork the repository into your own Github account.
+1. Please include unit tests for all new code. (Yes, we know not all
    existing code has tests. We're slowly fixing that, and contributions of tests
    for existing code are much appreciated.
-5. Make sure all existing tests pass. (gradlew test)
-6. Associate the change with an existing issue or [file a new issue](https://github.com/GoogleCloudPlatform/gcloud-intellij/issues/new). 
-7. Create a pull request and send it to gcloud-intellij:master. 
+1. Make sure all existing tests pass. (gradlew test)
+1. Associate the change with an existing issue or [file a new issue](https://github.com/GoogleCloudPlatform/gcloud-intellij/issues/new).
+1. Create a pull request and send it to gcloud-intellij:master.
 
 
 Unless otherwise noted, our source files are distributed under


### PR DESCRIPTION
I added a pointer to the Google Java style guide to our contributors instructions.