### PR TITLE
Fix several issues reported by FindBugs

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -152,3 +152,4 @@ clouddebug.background.listener.general.error.message=There was an unexpected err
 clouddebug.debug.targets.error=Error accessing debug targets: {0}
 clouddebug.debug.targets.accessdenied=Access denied. You may not have the necessary permissions to run Cloud Debugger with this project.
 
+settings.error.closing.file=Error closing settings file {0}.\nError details: {1}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentRunConfigurationEditor.java
@@ -58,13 +58,11 @@ public class ManagedVmDeploymentRunConfigurationEditor extends
   private TextFieldWithBrowseButton dockerFilePathField;
   private JButton generateAppYamlButton;
   private JButton generateDockerfileButton;
-  private AppEngineHelper appEngineHelper;
 
 
   public ManagedVmDeploymentRunConfigurationEditor(final Project project,
       final DeploymentSource source, final AppEngineHelper appEngineHelper) {
     this.project = project;
-    this.appEngineHelper = appEngineHelper;
     configTypeComboBox.setModel(new DefaultComboBoxModel(ConfigType.values()));
     configTypeComboBox.setSelectedItem(ConfigType.AUTO);
     mvmConfigFilesPanel.setVisible(false);

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudLineBreakpointProperties.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudLineBreakpointProperties.java
@@ -20,6 +20,8 @@ import com.intellij.util.xmlb.annotations.Tag;
 import com.intellij.xdebugger.breakpoints.XBreakpointProperties;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
+
 /**
  * CloudLineBreakpointProperties holds custom properties not normally set on a java line breakpoint. Right now, this is
  * just watch expressions.  Custom conditions are supported by default as is the enabled state and other attributes such
@@ -68,7 +70,9 @@ public class CloudLineBreakpointProperties extends XBreakpointProperties<CloudLi
 
   public final boolean setWatchExpressions(@Nullable String[] watchExpressions) {
     boolean changed = !arrayEqual(myWatchExpressions, watchExpressions);
-    myWatchExpressions = watchExpressions;
+    if (changed) {
+      myWatchExpressions = watchExpressions == null ? null : Arrays.copyOf(watchExpressions, watchExpressions.length);
+    }
     return changed;
   }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/git/GcpCheckoutProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/git/GcpCheckoutProvider.java
@@ -109,7 +109,7 @@ public class GcpCheckoutProvider implements CheckoutProvider {
           cloneResult.set(doClone(project, indicator, git, directoryName, parentDirectory, sourceRepositoryURL));
         }
         finally {
-          context.Close();
+          context.close();
         }
       }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/git/GcpHttpAuthDataProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/git/GcpHttpAuthDataProvider.java
@@ -136,7 +136,7 @@ public class GcpHttpAuthDataProvider implements GitHttpAuthDataProvider {
 
   @NotNull
   public static Context createContext(@Nullable String userName) {
-    return Context.Create(userName);
+    return Context.create(userName);
   }
 
   @Nullable
@@ -192,14 +192,14 @@ public class GcpHttpAuthDataProvider implements GitHttpAuthDataProvider {
       myUserName = userName;
     }
 
-    public static Context Create(@Nullable String userName) {
+    public static Context create(@Nullable String userName) {
       Context newContext = new Context(userName);
       assert ourCurrentContext == null;
       ourCurrentContext = newContext;
       return newContext;
     }
 
-    public void Close() {
+    public void close() {
       if (ourCurrentContext == this) {
         ourCurrentContext = null;
       }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/settings/ImportSettings.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/settings/ImportSettings.java
@@ -16,6 +16,7 @@
 package com.google.gct.idea.settings;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.gct.idea.util.GctBundle;
 import com.intellij.ide.IdeBundle;
 import com.intellij.ide.actions.ImportSettingsFilenameFilter;
 import com.intellij.ide.plugins.PluginManager;
@@ -55,6 +56,7 @@ public class ImportSettings {
    */
   public static void doImport(String path) {
     final File saveFile = new File(path);
+    ZipFile saveZipFile = null;
     try {
       if (!saveFile.exists()) {
         Messages.showErrorDialog(IdeBundle.message("error.cannot.find.file", presentableFileName(saveFile)), DIALOG_TITLE);
@@ -62,7 +64,8 @@ public class ImportSettings {
       }
 
       // What is this file used for?
-      final ZipEntry magicEntry = new ZipFile(saveFile).getEntry(SETTINGS_JAR_MARKER);
+      saveZipFile = new ZipFile(saveFile);
+      final ZipEntry magicEntry = saveZipFile.getEntry(SETTINGS_JAR_MARKER);
       if (magicEntry == null) {
         Messages.showErrorDialog("The file " + presentableFileName(saveFile) + " contains no settings to import",
           DIALOG_TITLE);
@@ -121,6 +124,16 @@ public class ImportSettings {
     catch (IOException e1) {
       Messages.showErrorDialog(IdeBundle.message("error.reading.settings.file.2", presentableFileName(saveFile), e1.getMessage()),
                                DIALOG_TITLE);
+    } finally {
+      try {
+        if (saveZipFile != null) {
+          saveZipFile.close();
+        }
+      } catch (IOException e1) {
+        Messages.showErrorDialog(
+          GctBundle.message("settings.error.closing.file", presentableFileName(saveFile), e1.getMessage()),
+                            DIALOG_TITLE);
+      }
     }
   }
 


### PR DESCRIPTION
Addresses several issues reported by FindBugs. (#241)

1. Remove unused field and local variable
No one references it. (Anonymous classes may look like they would reference it later, but they are actually referencing another 'appEngineHelper' qualified with 'final'.
 
2. Copy an array when storing it (i.e., not a ref to a mutable outside object)
Security issue. It is currently storing a reference to a mutable external array. I've checked all usages of 'setWatchExpression' function in the codebase, and it is safe to make a copy. I reckon that performance impact of copying is negligible.

3. Start method names with lower case letters
Close() -> close(), Create() -> create(). Not sure if they were intended though.

4. Always close ZipFile as soon as possible
Not sure if it is tolerable to let it open for a while in this situation.