### PR TITLE
Avoid bad practice of comparing Boolean

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/PsiUtils.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/PsiUtils.java
@@ -201,12 +201,13 @@ public class PsiUtils {
       return false;
     }
 
-    return Boolean.TRUE == type.accept(new PsiTypeVisitor<Boolean>() {
+    Boolean accepted = type.accept(new PsiTypeVisitor<Boolean>() {
       @Nullable
       @Override
       public Boolean visitClassType(PsiClassType classType) {
         return classType.getParameterCount() > 0;
       }
     });
+    return Boolean.TRUE.equals(accepted);
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/BreakpointUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/BreakpointUtil.java
@@ -41,7 +41,7 @@ public class BreakpointUtil {
    */
   @Nullable
   public static String getUserErrorMessage(@Nullable StatusMessage statusMessage) {
-    if (statusMessage == null || statusMessage.getIsError() != Boolean.TRUE) {
+    if (statusMessage == null || !Boolean.TRUE.equals(statusMessage.getIsError())) {
       return null;
     }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudBreakpointHandler.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudBreakpointHandler.java
@@ -100,7 +100,7 @@ public class CloudBreakpointHandler
    */
   public void cloneToNewBreakpoints(@NotNull final List<Breakpoint> serverBreakpoints) {
     for (Breakpoint serverBreakpoint : serverBreakpoints) {
-      if (serverBreakpoint.getIsFinalState() != Boolean.TRUE) {
+      if (!Boolean.TRUE.equals(serverBreakpoint.getIsFinalState())) {
         continue;
       }
 
@@ -174,7 +174,7 @@ public class CloudBreakpointHandler
   {
     boolean addedBreakpoint = false;
     for (final Breakpoint serverBreakpoint : serverBreakpoints) {
-      if (serverBreakpoint.getIsFinalState() == Boolean.TRUE) {
+      if (Boolean.TRUE.equals(serverBreakpoint.getIsFinalState())) {
         continue;
       }
 
@@ -254,7 +254,7 @@ public class CloudBreakpointHandler
    * Called when the user deletes a snapshot from the snapshot list.
    */
   public void deleteBreakpoint(@NotNull Breakpoint serverBreakpoint) {
-    if (serverBreakpoint.getIsFinalState() != Boolean.TRUE) {
+    if (!Boolean.TRUE.equals(serverBreakpoint.getIsFinalState())) {
       setStateToDisabled(serverBreakpoint);
     }
     process.getStateController().deleteBreakpointAsync(serverBreakpoint.getId());

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcess.java
@@ -296,7 +296,7 @@ public class CloudDebugProcess extends XDebugProcess implements CloudBreakpointL
                 // user clicked item.  This prevents multiple (and possibly out of order) selections
                 // getting queued up.
                 if (id.equals(navigatedSnapshotId)) {
-                  if (result.getIsFinalState() != Boolean.TRUE || result.getStackFrames() == null) {
+                  if (!Boolean.TRUE.equals(result.getIsFinalState()) || result.getStackFrames() == null) {
                     getBreakpointHandler().navigateTo(result);
                     if (result.getStackFrames() == null) {
                       navigateToBreakpoint(result);
@@ -354,18 +354,18 @@ public class CloudDebugProcess extends XDebugProcess implements CloudBreakpointL
           continue;
         }
 
-        if (breakpoint.getIsFinalState() == Boolean.TRUE &&
-            (breakpoint.getStatus() == null || breakpoint.getStatus().getIsError() != Boolean.TRUE)) {
+        if (Boolean.TRUE.equals(breakpoint.getIsFinalState()) &&
+            (breakpoint.getStatus() == null || !Boolean.TRUE.equals(breakpoint.getStatus().getIsError()))) {
           if (!getXDebugSession().isStopped()) {
             getBreakpointHandler().setStateToDisabled(breakpoint);
           }
         }
-        else if (breakpoint.getIsFinalState() == Boolean.TRUE) {
+        else if (Boolean.TRUE.equals(breakpoint.getIsFinalState())) {
           // then this is an error state breakpoint.
           com.intellij.debugger.ui.breakpoints.Breakpoint cloudBreakpoint =
             BreakpointManager.getJavaBreakpoint(breakpointHit);
           if (breakpoint.getStatus() != null &&
-              breakpoint.getStatus().getIsError() == Boolean.TRUE &&
+              Boolean.TRUE.equals(breakpoint.getStatus().getIsError()) &&
               cloudBreakpoint instanceof CloudLineBreakpointType.CloudLineBreakpoint) {
             CloudLineBreakpoint cloudLineBreakpoint = (CloudLineBreakpoint) cloudBreakpoint;
             cloudLineBreakpoint

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
@@ -161,7 +161,7 @@ public class CloudDebugProcessStateController {
     final SettableFuture<Breakpoint> future = SettableFuture.create();
     for (Breakpoint serverBreakpointCandidate : currentList) {
       if (serverBreakpointCandidate.getId().equals(id)
-          && serverBreakpointCandidate.getIsFinalState() != Boolean.TRUE) {
+          && !Boolean.TRUE.equals(serverBreakpointCandidate.getIsFinalState())) {
         handler.onSuccess(serverBreakpointCandidate);
         return;
       }
@@ -221,7 +221,7 @@ public class CloudDebugProcessStateController {
           List<Breakpoint> currentList = state.getCurrentServerBreakpointList();
           SourceLocation location = serverBreakpoint.getLocation();
           for (Breakpoint serverBp : currentList) {
-            if (serverBp.getIsFinalState() != Boolean.TRUE &&
+            if (!Boolean.TRUE.equals(serverBp.getIsFinalState()) &&
                 serverBp.getLocation().getLine() != null &&
                 serverBp.getLocation().getLine().equals(location.getLine()) &&
                 !Strings.isNullOrEmpty(serverBp.getLocation().getPath()) &&
@@ -236,7 +236,7 @@ public class CloudDebugProcessStateController {
           if (addResponse != null && addResponse.getBreakpoint() != null) {
             Breakpoint result = addResponse.getBreakpoint();
             if (result.getStatus() != null &&
-                result.getStatus().getIsError() == Boolean.TRUE &&
+                Boolean.TRUE.equals(result.getStatus().getIsError()) &&
                 handler != null &&
                 result.getStatus().getDescription() != null) {
               handler.onError(BreakpointUtil.getUserErrorMessage(result.getStatus()));

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/SnapshotsModel.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/SnapshotsModel.java
@@ -64,12 +64,12 @@ class SnapshotsModel extends AbstractTableModel {
           // If a new breakpoint is in final state *and*
           // the old model didn't know about that breakpoint as being final (and not new)
           // then we mark it.
-          if (newBreakpoint.getIsFinalState() != Boolean.TRUE) {
+          if (!Boolean.TRUE.equals(newBreakpoint.getIsFinalState())) {
             continue;
           }
           if (tempHashMap.containsKey(newBreakpoint.getId())) {
             Breakpoint previousBreakpoint = tempHashMap.get(newBreakpoint.getId());
-            if (previousBreakpoint.getIsFinalState() == Boolean.TRUE) {
+            if (Boolean.TRUE.equals(previousBreakpoint.getIsFinalState())) {
               if (!oldModel.isNewlyReceived(previousBreakpoint.getId())) {
                 continue;
               }
@@ -141,15 +141,15 @@ class SnapshotsModel extends AbstractTableModel {
 
     switch (columnIndex) {
       case 0:
-        if (breakpoint.getStatus() != null && breakpoint.getStatus().getIsError() == Boolean.TRUE) {
+        if (breakpoint.getStatus() != null && Boolean.TRUE.equals(breakpoint.getStatus().getIsError())) {
           return GoogleCloudToolsIcons.CLOUD_BREAKPOINT_ERROR;
         }
-        if (breakpoint.getIsFinalState() != Boolean.TRUE) {
+        if (!Boolean.TRUE.equals(breakpoint.getIsFinalState())) {
           return GoogleCloudToolsIcons.CLOUD_BREAKPOINT_CHECKED;
         }
         return GoogleCloudToolsIcons.CLOUD_BREAKPOINT_FINAL;
       case 1:
-        if (breakpoint.getIsFinalState() != Boolean.TRUE) {
+        if (!Boolean.TRUE.equals(breakpoint.getIsFinalState())) {
           return GctBundle.getString("clouddebug.pendingstatus");
         }
         return BreakpointUtil.parseDateTime(breakpoint.getFinalTime());


### PR DESCRIPTION
Fix a subset of #241 (FindBugs issue: RC_REF_COMPARISON_BAD_PRACTICE_BOOLEAN).

Comparing Booleans using == or != might pose a problem, e.g., if Boolean objects are created using the 'new Boolean(b)' constructor (although creating such objects would be an unusual practice). In such cases, == or != can give different results than '.equals()' would do.

However, this PR hurts readability slightly IMHO. If you think it is just ok to use == or !=, feel free to ditch this PR.