### PR TITLE
Address potential NullPointerExceptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ subprojects {
             exclude group: 'org.hamcrest', module: 'hamcrest-core'
         }
         testCompile 'org.hamcrest:hamcrest-all:1.3'
+        compile 'com.google.code.findbugs:annotations:3.0.1'
     }
 
     apply plugin: 'findbugs'
@@ -70,7 +71,7 @@ subprojects {
         ignoreFailures = true
         sourceSets = [sourceSets.main]
         effort = "max"
-        toolVersion = '2.0.3'
+        toolVersion = '3.0.1'
     }
 
     tasks.withType(FindBugs) {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/EndpointUtilities.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/EndpointUtilities.java
@@ -26,6 +26,8 @@ import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiModifierList;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
@@ -74,8 +76,10 @@ public class EndpointUtilities {
    * @param psiMethod PsiMethod to be parsed.
    * @return  Returns true is a method is public but not static. Returns false otherwise.
    */
+  @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                      justification = "PsiMethod.getModifierList() is @NotNull")
   public static boolean isApiMethod(@NonNls PsiMethod psiMethod) {
-    PsiModifierList psiModifierList =  psiMethod.getModifierList();
+    PsiModifierList psiModifierList = psiMethod.getModifierList();
     if(psiModifierList.hasModifierProperty(PsiModifier.PUBLIC) &&
        !psiModifierList.hasModifierProperty(PsiModifier.STATIC)) {
       return true;
@@ -90,6 +94,8 @@ public class EndpointUtilities {
     return word.replaceAll("[.]+",".");
   }
 
+  @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                      justification = "PsiMethod.getModifierList() is @NotNull")
   public static boolean isPublicNullaryConstructor(PsiMethod method) {
     if(!method.isConstructor()) {
       return false;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNamespaceInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNamespaceInspection.java
@@ -29,6 +29,9 @@ import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiAnnotationMemberValue;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -70,12 +73,19 @@ public class ApiNamespaceInspection extends EndpointInspectionBase{
        * OwnerName and OwnerDomain attributes are not specified.
        */
       @Override
+      @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                          justification = "PsiAnnotation.findAttributeValue() will not return null in our case")
       public void visitAnnotation(PsiAnnotation annotation) {
         if (!EndpointUtilities.isEndpointClass(annotation)) {
           return;
         }
 
-        if(!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_API_NAMESPACE)) {
+        String annotationQualifiedName = annotation.getQualifiedName();
+        if (annotationQualifiedName == null) {
+          return;
+        }
+
+        if(!annotationQualifiedName.equals(GctConstants.APP_ENGINE_ANNOTATION_API_NAMESPACE)) {
           return;
         }
 
@@ -155,8 +165,12 @@ public class ApiNamespaceInspection extends EndpointInspectionBase{
       }
 
       PsiAnnotation annotation = (PsiAnnotation)psiElement;
+      String annotationQualifiedName = annotation.getQualifiedName();
+      if (annotationQualifiedName == null) {
+        return;
+      }
 
-      if(!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_API_NAMESPACE)) {
+      if(!annotationQualifiedName.equals(GctConstants.APP_ENGINE_ANNOTATION_API_NAMESPACE)) {
         return;
       }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/FullJavaNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/FullJavaNameInspection.java
@@ -97,15 +97,23 @@ public class FullJavaNameInspection extends EndpointInspectionBase {
           return;
         }
 
-        String javaName = psiMethod.getContainingClass().getQualifiedName() + "." + psiMethod.getName();
+        PsiClass containingClass = psiMethod.getContainingClass();
+        String containingClassQualifiedName = containingClass == null ? "null" : containingClass.getQualifiedName();
+        String javaName = containingClassQualifiedName + "." + psiMethod.getName();
+
         PsiMethod seenMethod = javaMethodNames.get(javaName);
         if (seenMethod == null) {
           javaMethodNames.put(javaName, psiMethod);
         } else {
-          String psiMethodName = psiMethod.getContainingClass().getName() + "." + psiMethod.getName() +
+          String containingClassName = containingClass == null ? "null" : containingClass.getName();
+          String psiMethodName = containingClassName + "." + psiMethod.getName() +
             psiMethod.getParameterList().getText();
-          String seenMethodName = seenMethod.getContainingClass().getName() + "." + seenMethod.getName() +
-            seenMethod.getParameterList().getText();;
+
+          PsiClass seenContainingClass = seenMethod.getContainingClass();
+          String seenContainingClassName = seenContainingClass == null ? "null" : seenContainingClass.getName();
+          String seenMethodName = seenContainingClassName + "." + seenMethod.getName() +
+            seenMethod.getParameterList().getText();
+
           holder.registerProblem(psiMethod, "Overloaded methods are not supported. " +  javaName +
             " has at least one overload: " + psiMethodName + " and " + seenMethodName,
             new MyQuickFix());

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/FullMethodNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/FullMethodNameInspection.java
@@ -33,6 +33,8 @@ import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifierList;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -91,6 +93,8 @@ public class FullMethodNameInspection extends EndpointInspectionBase  {
        * Checks that the API method name specified in @APiMethod's name attribute is unique.
        * API methods.
        */
+      @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                          justification = "PsiMethod.getModifierList() is @NotNull")
       private void validateBackendMethodNameUnique(PsiMethod psiMethod, Map<String, PsiMethod> apiMethodNames) {
         // Check if method is a public or non-static
         if(!EndpointUtilities.isApiMethod(psiMethod)) {
@@ -154,7 +158,12 @@ public class FullMethodNameInspection extends EndpointInspectionBase  {
       }
 
       PsiAnnotation annotation = (PsiAnnotation)element;
-      if(!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_API_METHOD)) {
+      String annotationQualifiedName = annotation.getQualifiedName();
+      if (annotationQualifiedName == null) {
+        return;
+      }
+
+      if(!annotationQualifiedName.equals(GctConstants.APP_ENGINE_ANNOTATION_API_METHOD)) {
         return;
       }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/InvalidParameterAnnotationsInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/InvalidParameterAnnotationsInspection.java
@@ -31,6 +31,9 @@ import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.PsiParameter;
 import com.intellij.psi.PsiParameterList;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -70,6 +73,10 @@ public class InvalidParameterAnnotationsInspection extends EndpointInspectionBas
   public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
     return new EndpointPsiElementVisitor() {
       @Override
+      @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                          justification = "1. PsiMethod.getModifierList() is @NotNull;"
+                                        + "2. PsiAnnotation.findAttributeValue() will not return null in our case;"
+                                        + "3. PsiParameter.getModifierList() will not return null in our case")
       public void visitMethod (PsiMethod method){
         if (!EndpointUtilities.isEndpointClass(method)) {
           return;
@@ -170,6 +177,8 @@ public class InvalidParameterAnnotationsInspection extends EndpointInspectionBas
      * Remove @Default and @Nullable from the method parameter if they exist.
      */
     @Override
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                        justification = "PsiMethod.getModifierList() is @NotNull")
     public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
       PsiElement element = descriptor.getPsiElement();
       if (element == null) {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/MethodNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/MethodNameInspection.java
@@ -79,7 +79,12 @@ public class MethodNameInspection extends EndpointInspectionBase {
           return;
         }
 
-        if(!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_API_METHOD)) {
+        String annotationQualifiedName = annotation.getQualifiedName();
+        if (annotationQualifiedName == null) {
+          return;
+        }
+
+        if(!annotationQualifiedName.equals(GctConstants.APP_ENGINE_ANNOTATION_API_METHOD)) {
           return;
         }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/NamedResourceInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/NamedResourceInspection.java
@@ -179,8 +179,13 @@ public class NamedResourceInspection extends EndpointInspectionBase {
       }
 
       PsiAnnotation annotation = (PsiAnnotation)element;
-      if((!annotation.getQualifiedName().equals("javax.inject.Named"))  &&
-        (!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_NAMED))) {
+      String annotationQualifiedName = annotation.getQualifiedName();
+      if (annotationQualifiedName == null) {
+        return;
+      }
+
+      if((!annotationQualifiedName.equals("javax.inject.Named"))  &&
+        (!annotationQualifiedName.equals(GctConstants.APP_ENGINE_ANNOTATION_NAMED))) {
           return;
       }
 
@@ -242,8 +247,13 @@ public class NamedResourceInspection extends EndpointInspectionBase {
       }
 
       PsiAnnotation annotation = (PsiAnnotation)element;
-      if((!annotation.getQualifiedName().equals("javax.inject.Named"))  &&
-         (!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_NAMED))) {
+      String annotationQualifiedName = annotation.getQualifiedName();
+      if (annotationQualifiedName == null) {
+        return;
+      }
+
+      if((!annotationQualifiedName.equals("javax.inject.Named"))  &&
+         (!annotationQualifiedName.equals(GctConstants.APP_ENGINE_ANNOTATION_NAMED))) {
         return;
       }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ResourceParameterInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ResourceParameterInspection.java
@@ -33,6 +33,9 @@ import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.PsiParameter;
 import com.intellij.psi.PsiType;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -106,6 +109,8 @@ public class ResourceParameterInspection extends EndpointInspectionBase {
         }
       }
 
+      @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                          justification = "PsiParameter.getModifierList() will not return null in our case")
       private void validateMethodParameters(PsiParameter psiParameter, Project project) {
         // Check if parameter is of entity (resource) type which is not of parameter type or injected type.
         PsiType type = psiParameter.getType();

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/RestSignatureInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/RestSignatureInspection.java
@@ -26,6 +26,9 @@ import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.*;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -94,6 +97,8 @@ public class RestSignatureInspection extends EndpointInspectionBase {
        * prefix.
        */
       @Override
+      @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                          justification = "PsiMethod.getName() is @NotNull")
       public String guessResourceName(PsiMethod method) {
         String methodName = method.getName();
         return methodNamePrefix.length() >= methodName.length() ? null :
@@ -108,6 +113,8 @@ public class RestSignatureInspection extends EndpointInspectionBase {
        * prefix.
        */
       @Override
+      @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                          justification = "PsiMethod.getName() is @NotNull")
       public String guessResourceName(PsiMethod method) {
         String methodName = method.getName();
         return methodNamePrefix.length() >= methodName.length() ? null :
@@ -166,7 +173,8 @@ public class RestSignatureInspection extends EndpointInspectionBase {
         return null;
       }
 
-      return getSimpleName(project, method.getReturnType()).toLowerCase();
+      String simpleName = getSimpleName(project, method.getReturnType());
+      return simpleName == null ? null : simpleName.toLowerCase();
     }
 
     @Nullable
@@ -288,6 +296,8 @@ public class RestSignatureInspection extends EndpointInspectionBase {
    * @param psiMethod the method hose HTTP method is to be determined
    * @return the http Method pf psiMethod
    */
+  @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                      justification = "PsiMethod.getModifierList() is @NotNull")
   public String getHttpMethod(PsiMethod psiMethod) {
     PsiModifierList modifierList = psiMethod.getModifierList();
     String httpMethod = null;
@@ -320,6 +330,8 @@ public class RestSignatureInspection extends EndpointInspectionBase {
    * @param psiMethod the method whose path is to be determined
    * @return the path for psiMethod
    */
+  @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+                      justification = "PsiMethod.getModifierList() is @NotNull")
   public String getPath(PsiMethod psiMethod) {
     PsiModifierList modifierList = psiMethod.getModifierList();
     String path = null;
@@ -397,6 +409,10 @@ public class RestSignatureInspection extends EndpointInspectionBase {
   @Nullable
   private String getResourceProperty(PsiMethod psiMethod) {
     PsiClass psiClass = psiMethod.getContainingClass();
+    if (psiClass == null) {
+      return null;
+    }
+
     PsiModifierList modifierList = psiClass.getModifierList();
     String resource = null;
 
@@ -448,7 +464,12 @@ public class RestSignatureInspection extends EndpointInspectionBase {
   private String getAttributeFromAnnotation (PsiAnnotation annotation, String annotationType,
     final String attribute) throws InvalidAnnotationException, MissingAttributeException {
 
-    if(annotation.getQualifiedName().equals(annotationType)) {
+    String annotationQualifiedName = annotation.getQualifiedName();
+    if (annotationQualifiedName == null) {
+      throw new InvalidAnnotationException(annotation, annotationType);
+    }
+
+    if(annotationQualifiedName.equals(annotationType)) {
       PsiAnnotationMemberValue annotationMemberValue =  annotation.findAttributeValue(attribute);
       if(annotationMemberValue == null) {
         throw new MissingAttributeException(annotation, attribute);


### PR DESCRIPTION
Fix a subset of #241 (FindBugs issue: NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE).

Addresses points of a potential NullPointerException. Some warnings are suppressed.

Some explanations:
1. PsiAnnotation.findAttributeValue() is 'Nullable', but comments in our source seems to saying that it will return some default value in those case.
2. PsiParameter.getModifierList() is 'Nullable'. For example, if called by an anonymous inner class, it will return null as it cannot have modifiers. However, since we are calling it against parameters, I think it will not return null in our case.

About suppressing warnings: granularity is per method. Unfortunately, no finer granularity seems possible. That is, we will not be able to further detect this issue for the methods annotated to suppress this warning.