### PR TITLE
Address two FindBugs warnings.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/NamedResourceInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/NamedResourceInspection.java
@@ -210,7 +210,7 @@ public class NamedResourceInspection extends EndpointInspectionBase {
    * LocalQuickFix to add a query name to an @Named without a specified query name.
    */
   public class MissingNameQuickFix implements LocalQuickFix {
-    private final String DEFAULT_PARAMETER_NAME = "myName";
+    private static final String DEFAULT_PARAMETER_NAME = "myName";
 
     @NotNull
     @Override

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
@@ -158,7 +158,6 @@ public class CloudDebugProcessStateController {
       return;
     }
     List<Breakpoint> currentList = state.getCurrentServerBreakpointList();
-    final SettableFuture<Breakpoint> future = SettableFuture.create();
     for (Breakpoint serverBreakpointCandidate : currentList) {
       if (serverBreakpointCandidate.getId().equals(id)
           && !Boolean.TRUE.equals(serverBreakpointCandidate.getIsFinalState())) {


### PR DESCRIPTION
#241. Surprisingly, after this fix, there will be left only a couple of warnings that need individual attention. All the other remaining issues will be either a NullPointerException case or a redundant null checking.

1. Put 'static' to a constant field.
2. Remove an unused local variable (SettableFuture).

For the second one, please take a look at the code carefully. It is certain that the variable is never used. However, because it is a Future object from the beginning, its presents simply makes me believe that there should have been something going on with this object.