### PR TITLE
Address five FindBugs warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ subprojects {
             exclude group: 'org.hamcrest', module: 'hamcrest-core'
         }
         testCompile 'org.hamcrest:hamcrest-all:1.3'
+        compile 'com.google.code.findbugs:annotations:2.0.3'
     }
 
     apply plugin: 'findbugs'
@@ -71,6 +72,7 @@ subprojects {
         sourceSets = [sourceSets.main]
         effort = "max"
         toolVersion = '2.0.3'
+        excludeFilter = file('../findbugs-excludefilter.xml')
     }
 
     tasks.withType(FindBugs) {

--- a/common-lib/src/main/java/com/google/gct/idea/BasePluginInfoService.java
+++ b/common-lib/src/main/java/com/google/gct/idea/BasePluginInfoService.java
@@ -29,6 +29,8 @@ import com.intellij.util.PlatformUtils;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Set;
+
 /**
  * Subclasses of this class will inherit a full implementation of the {@link PluginInfoService}.
  */
@@ -83,14 +85,15 @@ public abstract class BasePluginInfoService implements PluginInfoService {
    */
   @Override
   public boolean shouldEnable(Feature feature) {
-    if (feature.getSupportedPlatforms() != null &&
-        feature.getSupportedPlatforms().contains(getCurrentPlatform())) {
+    Set<IntelliJPlatform> supportedPlatforms = feature.getSupportedPlatforms();
+    if (supportedPlatforms != null && supportedPlatforms.contains(getCurrentPlatform())) {
       return true;
     }
     if (Boolean.parseBoolean(flagReader.getFlagString(feature.getResourceFlagName()))) {
       return true;
     }
-    if (Boolean.getBoolean(feature.getSystemFlagName())) {
+    String flagName = feature.getSystemFlagName();
+    if (flagName != null && Boolean.getBoolean(flagName)) {
       return true;
     }
     return false;

--- a/findbugs-excludefilter.xml
+++ b/findbugs-excludefilter.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!--
+    Suppress the following warnings:
+      1. Inefficient 'new String("plain string")' constructor
+      2. Redundant null checking of known non-null value
+  -->
+  <Match>
+    <Bug pattern="DM_STRING_CTOR, RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+  </Match>
+</FindBugsFilter>

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/RestSignatureInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/RestSignatureInspection.java
@@ -494,7 +494,7 @@ public class RestSignatureInspection extends EndpointInspectionBase {
    * that does not have @Nullable/@Default.
    */
   private String getPathParameter(PsiMethod method) {
-    String path = "";
+    StringBuilder path = new StringBuilder();
     EndpointPsiElementVisitor elementVisitor = new EndpointPsiElementVisitor();
     List<String> annotions =
       Arrays.asList(GctConstants.APP_ENGINE_ANNOTATION_NULLABLE, "javax.annotation.Nullable", GctConstants.APP_ENGINE_ANNOTATION_DEFAULT_VALUE);
@@ -512,11 +512,11 @@ public class RestSignatureInspection extends EndpointInspectionBase {
 
       PsiAnnotationMemberValue namedValue = elementVisitor.getNamedAnnotationValue(aParameter);
       if(namedValue != null) {
-        path += "/{}";
+        path.append("/{}");
       }
     }
 
-    return path;
+    return path.toString();
   }
 
   /**

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebuggerClient.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebuggerClient.java
@@ -90,6 +90,10 @@ public class CloudDebuggerClient {
    * The function may return null if the user is not logged in.
    */
   @Nullable
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+      value = "AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION",
+      justification = "Tolerable; ok to create and use duplicate or dangling Debugger clients"
+  )
   private static Debugger getClient(final @Nullable String userEmail, final int timeout) {
     if (Strings.isNullOrEmpty(userEmail)) {
       LOG.warn("unexpected null email in controller initialize.");


### PR DESCRIPTION
#241. Address the following five FindBugs warnings. Set up FindBugs filter configuration (a new XML file) as well.

1. Concurrent calls may not be atomic (1 instance)
There do exists a concurrency problem because concurrent calls are currently not atomic. However, judging from the nature of using Cloud Debugger, I think this is tolerable. Users may retry if an extremely-rarely-occurring error happens.

2. Inefficient 'new String("plain sring")' constructor (21 instances)
As discussed in a previous pull request, this disables the warning once and for all.

3. Redundant null checks of known non-null values (66 instances)
As discussed, this disables the warning once and for all.

4. String concat("+") in a loop

5. Address NPE (2 instances)