### PR TITLE
Prevent NullPointerException

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNameInspection.java
@@ -80,12 +80,7 @@ public class ApiNameInspection extends EndpointInspectionBase {
           return;
         }
 
-        String annotationQualifiedName = annotation.getQualifiedName();
-        if(annotationQualifiedName == null) {
-          return;
-        }
-
-        if(!annotationQualifiedName.equals(GctConstants.APP_ENGINE_ANNOTATION_API)) {
+        if(!GctConstants.APP_ENGINE_ANNOTATION_API.equals(annotation.getQualifiedName())) {
           return;
         }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNamespaceInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNamespaceInspection.java
@@ -75,7 +75,7 @@ public class ApiNamespaceInspection extends EndpointInspectionBase{
           return;
         }
 
-        if(!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_API_NAMESPACE)) {
+        if(!GctConstants.APP_ENGINE_ANNOTATION_API_NAMESPACE.equals(annotation.getQualifiedName())) {
           return;
         }
 
@@ -155,8 +155,7 @@ public class ApiNamespaceInspection extends EndpointInspectionBase{
       }
 
       PsiAnnotation annotation = (PsiAnnotation)psiElement;
-
-      if(!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_API_NAMESPACE)) {
+      if(!GctConstants.APP_ENGINE_ANNOTATION_API_NAMESPACE.equals(annotation.getQualifiedName())) {
         return;
       }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/FullMethodNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/FullMethodNameInspection.java
@@ -154,7 +154,7 @@ public class FullMethodNameInspection extends EndpointInspectionBase  {
       }
 
       PsiAnnotation annotation = (PsiAnnotation)element;
-      if(!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_API_METHOD)) {
+      if(!GctConstants.APP_ENGINE_ANNOTATION_API_METHOD.equals(annotation.getQualifiedName())) {
         return;
       }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/MethodNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/MethodNameInspection.java
@@ -79,7 +79,7 @@ public class MethodNameInspection extends EndpointInspectionBase {
           return;
         }
 
-        if(!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_API_METHOD)) {
+        if(!GctConstants.APP_ENGINE_ANNOTATION_API_METHOD.equals(annotation.getQualifiedName())) {
           return;
         }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/NamedResourceInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/NamedResourceInspection.java
@@ -179,8 +179,8 @@ public class NamedResourceInspection extends EndpointInspectionBase {
       }
 
       PsiAnnotation annotation = (PsiAnnotation)element;
-      if((!annotation.getQualifiedName().equals("javax.inject.Named"))  &&
-        (!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_NAMED))) {
+      if((!"javax.inject.Named".equals(annotation.getQualifiedName()))  &&
+        (!GctConstants.APP_ENGINE_ANNOTATION_NAMED.equals(annotation.getQualifiedName()))) {
           return;
       }
 
@@ -242,8 +242,8 @@ public class NamedResourceInspection extends EndpointInspectionBase {
       }
 
       PsiAnnotation annotation = (PsiAnnotation)element;
-      if((!annotation.getQualifiedName().equals("javax.inject.Named"))  &&
-         (!annotation.getQualifiedName().equals(GctConstants.APP_ENGINE_ANNOTATION_NAMED))) {
+      if((!"javax.inject.Named".equals(annotation.getQualifiedName()))  &&
+         (!GctConstants.APP_ENGINE_ANNOTATION_NAMED.equals(annotation.getQualifiedName()))) {
         return;
       }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/RestSignatureInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/RestSignatureInspection.java
@@ -166,7 +166,8 @@ public class RestSignatureInspection extends EndpointInspectionBase {
         return null;
       }
 
-      return getSimpleName(project, method.getReturnType()).toLowerCase();
+      String simpleName = getSimpleName(project, method.getReturnType());
+      return simpleName == null ? null : simpleName.toLowerCase();
     }
 
     @Nullable
@@ -448,7 +449,12 @@ public class RestSignatureInspection extends EndpointInspectionBase {
   private String getAttributeFromAnnotation (PsiAnnotation annotation, String annotationType,
     final String attribute) throws InvalidAnnotationException, MissingAttributeException {
 
-    if(annotation.getQualifiedName().equals(annotationType)) {
+    String annotationQualifiedName = annotation.getQualifiedName();
+    if (annotationQualifiedName == null) {
+      throw new InvalidAnnotationException(annotation, annotationType);
+    }
+
+    if(annotationQualifiedName.equals(annotationType)) {
       PsiAnnotationMemberValue annotationMemberValue =  annotation.findAttributeValue(attribute);
       if(annotationMemberValue == null) {
         throw new MissingAttributeException(annotation, attribute);


### PR DESCRIPTION
FindBugs issues #241. Address some (not all) of possible NullPointerExceptions. All the cases in this PR can produce NPE according to method contracts (i.e., @Nullable). It also seems that they can actually return null from their contexts.

After this PR, all other remaining 38 instances of the possible NPE warning can be suppressed (although there isn't an optimal way to suppress them).