### PR TITLE
Use custom PMD ruleset / Follow PMD suggestions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,9 @@ subprojects {
     pmd {
         ignoreFailures = true
         sourceSets = [sourceSets.main]
+        // Don't use the default ruleset but use a custom ruleset to exclude some PMD rules.
+        ruleSets = []
+        ruleSetFiles = files("../custom-pmd-ruleset.xml");
     }
 
     apply plugin: 'jdepend'

--- a/common-lib/src/main/java/com/google/gct/idea/flags/PropertiesFileFlagReader.java
+++ b/common-lib/src/main/java/com/google/gct/idea/flags/PropertiesFileFlagReader.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.diagnostic.Logger;
 
 import org.jetbrains.annotations.Nullable;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;

--- a/custom-pmd-ruleset.xml
+++ b/custom-pmd-ruleset.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  name="Android Application Rules"
+  xmlns="http://pmd.sf.net/ruleset/1.0.0"
+  xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd"
+  xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd" >
+
+  <description>We selectively activate a certain subset of the PMD rules for Java. These rules are actually a larger set than what the Gradle PMD plugin uses as a default.</description>
+
+  <!--rule ref="rulesets/java/android.xml" /-->
+  <rule ref="rulesets/java/basic.xml" />
+  <rule ref="rulesets/java/braces.xml" />
+  <!--rule ref="rulesets/java/clone.xml" /-->
+  <!--rule ref="rulesets/java/codesize.xml" /-->
+  <!--rule ref="rulesets/java/comments.xml" /-->
+  <!--rule ref="rulesets/java/controversial.xml" /-->
+  <!--rule ref="rulesets/java/coupling.xml" /-->
+  <!--rule ref="rulesets/java/design.xml" /-->
+  <rule ref="rulesets/java/empty.xml" />
+  <rule ref="rulesets/java/finalizers.xml" />
+  <rule ref="rulesets/java/imports.xml" />
+  <!--rule ref="rulesets/java/j2ee.xml" /-->
+  <!--rule ref="rulesets/java/javabeans.xml" /-->
+  <!--rule ref="rulesets/java/junit.xml" /-->
+  <!--rule ref="rulesets/java/logging-jakarta-commons.xml" /-->
+  <!--rule ref="rulesets/java/logging-java.xml" /-->
+  <!--rule ref="rulesets/java/migrating.xml" /-->
+  <!--rule ref="rulesets/java/migrating_to_13.xml" /-->
+  <!--rule ref="rulesets/java/migrating_to_14.xml" /-->
+  <!--rule ref="rulesets/java/migrating_to_15.xml" /-->
+  <!--rule ref="rulesets/java/migrating_to_junit4.xml" /-->
+  <!--rule ref="rulesets/java/naming.xml" /-->
+  <!--rule ref="rulesets/java/optimizations.xml" /-->
+  <!--rule ref="rulesets/java/strictexception.xml" /-->
+  <!--rule ref="rulesets/java/strings.xml" /-->
+  <!--rule ref="rulesets/java/sunsecure.xml" /-->
+  <rule ref="rulesets/java/typeresolution.xml" />
+  <rule ref="rulesets/java/unnecessary.xml" >
+    <exclude name="UselessParentheses" />
+  </rule>
+  <!--rule ref="rulesets/java/unusedcode.xml" /-->
+
+</ruleset>

--- a/findbugs-excludefilter.xml
+++ b/findbugs-excludefilter.xml
@@ -6,6 +6,10 @@
       2. Redundant null checking of known non-null value
   -->
   <Match>
-    <Bug pattern="DM_STRING_CTOR, RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    <Or>
+      <Bug pattern="DM_STRING_CTOR" />
+      <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+      <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Or>
   </Match>
 </FindBugsFilter>

--- a/google-account-plugin/src/com/google/gct/login/CredentialedUserRoster.java
+++ b/google-account-plugin/src/com/google/gct/login/CredentialedUserRoster.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * {@link CredentialedUser} objects.
  */
 public class CredentialedUserRoster {
-  private final LinkedHashMap<String, CredentialedUser> allUsers = new LinkedHashMap<String, CredentialedUser>();
+  private final Map<String, CredentialedUser> allUsers = new LinkedHashMap<String, CredentialedUser>();
   private final Collection<GoogleLoginListener> listeners = Lists.newLinkedList();
   private CredentialedUser activeUser;
 
@@ -38,7 +38,7 @@ public class CredentialedUserRoster {
    * @return Copy of current logged in users.
    */
   @NotNull
-  public LinkedHashMap<String, CredentialedUser> getAllUsers() {
+  public Map<String, CredentialedUser> getAllUsers() {
     synchronized (this) {
       LinkedHashMap<String, CredentialedUser> clone = new LinkedHashMap<String, CredentialedUser>();
       clone.putAll(allUsers);

--- a/google-account-plugin/src/com/google/gct/login/GoogleLoginService.java
+++ b/google-account-plugin/src/com/google/gct/login/GoogleLoginService.java
@@ -22,7 +22,7 @@ import com.google.gct.login.ui.GoogleLoginActionButton;
 
 import org.jetbrains.annotations.Nullable;
 
-import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Provides Google user authentication services.
@@ -111,7 +111,7 @@ public interface GoogleLoginService {
   /**
    * Returns a copy of the map of the current logged in users.
    */
-  LinkedHashMap<String, CredentialedUser> getAllUsers();
+  Map<String, CredentialedUser> getAllUsers();
 
   /**
    * Returns the active user.

--- a/google-account-plugin/src/com/google/gct/login/IntellijGoogleLoginService.java
+++ b/google-account-plugin/src/com/google/gct/login/IntellijGoogleLoginService.java
@@ -56,7 +56,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.awt.Window;
 import java.io.IOException;
-import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.List;
 
 
@@ -269,7 +269,7 @@ public class IntellijGoogleLoginService implements GoogleLoginService {
   }
 
   @Override
-  public LinkedHashMap<String, CredentialedUser> getAllUsers() {
+  public Map<String, CredentialedUser> getAllUsers() {
     return users.getAllUsers();
   }
 

--- a/google-account-plugin/src/com/google/gct/login/ui/GoogleLoginAction.java
+++ b/google-account-plugin/src/com/google/gct/login/ui/GoogleLoginAction.java
@@ -17,7 +17,6 @@ package com.google.gct.login.ui;
 
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.actionSystem.ex.CustomComponentAction;
-import com.intellij.openapi.actionSystem.impl.ActionButton;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.ui.popup.ComponentPopupBuilder;
 import com.intellij.openapi.ui.popup.JBPopup;

--- a/google-account-plugin/src/com/google/gct/login/ui/GoogleLoginUsersPanel.java
+++ b/google-account-plugin/src/com/google/gct/login/ui/GoogleLoginUsersPanel.java
@@ -30,7 +30,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionListener;
-import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -254,7 +254,7 @@ public class GoogleLoginUsersPanel extends JPanel implements ListSelectionListen
   }
 
   private int initializeUsers() {
-    LinkedHashMap<String, CredentialedUser> allUsers = Services.getLoginService().getAllUsers();
+    Map<String, CredentialedUser> allUsers = Services.getLoginService().getAllUsers();
     listModel = new DefaultListModel();
 
     int activeUserIndex = allUsers.size();

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/EndpointUtilities.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/EndpointUtilities.java
@@ -19,7 +19,6 @@ package com.google.gct.idea.appengine.util;
 import com.google.gct.idea.appengine.GctConstants;
 
 import com.intellij.codeInsight.AnnotationUtil;
-import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNameInspection.java
@@ -135,7 +135,9 @@ public class ApiNameInspection extends EndpointInspectionBase {
     @Override
     public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
       PsiElement element = descriptor.getPsiElement();
-      if (element == null) return;
+      if (element == null) {
+        return;
+      }
 
       Editor editor = PsiUtilBase.findEditor(element);
       if (editor == null) {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/InvalidParameterAnnotationsInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/InvalidParameterAnnotationsInspection.java
@@ -134,7 +134,7 @@ public class InvalidParameterAnnotationsInspection extends EndpointInspectionBas
        * @return A collection of the parameter in <code>path</code>
        */
       private Collection<String> getPathParameters(String path) {
-        Pattern pathPattern = java.util.regex.Pattern.compile("\\{([^\\}]*)\\}");
+        Pattern pathPattern = Pattern.compile("\\{([^\\}]*)\\}");
         Matcher pathMatcher = pathPattern.matcher(path);
 
         Collection<String> pathParameters = new HashSet<String>();

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/MethodNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/MethodNameInspection.java
@@ -127,7 +127,9 @@ public class MethodNameInspection extends EndpointInspectionBase {
     @Override
     public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
       PsiElement element = descriptor.getPsiElement();
-      if (element == null) return;
+      if (element == null) {
+        return;
+      }
 
       Editor editor = PsiUtilBase.findEditor(element);
       if (editor == null) {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
@@ -19,7 +19,6 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.repackaged.com.google.common.base.Strings;
 import com.google.api.services.clouddebugger.Clouddebugger.Debugger;
 import com.google.api.services.clouddebugger.model.*;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.gct.idea.util.GctBundle;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ServerToIDEFileResolver.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ServerToIDEFileResolver.java
@@ -16,7 +16,6 @@
 package com.google.gct.idea.debugger;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
 
 import com.intellij.ide.highlighter.JavaFileType;
 import com.intellij.openapi.project.Project;
@@ -34,7 +33,6 @@ import com.intellij.util.indexing.FileBasedIndex;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 /**

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/BreakpointErrorStatusPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/BreakpointErrorStatusPanel.java
@@ -20,72 +20,17 @@ import com.google.gct.idea.debugger.CloudLineBreakpointType;
 
 import com.intellij.debugger.ui.breakpoints.Breakpoint;
 import com.intellij.debugger.ui.breakpoints.BreakpointManager;
-import com.intellij.ide.DataManager;
-import com.intellij.lang.Language;
-import com.intellij.openapi.Disposable;
-import com.intellij.openapi.actionSystem.ActionManager;
-import com.intellij.openapi.actionSystem.ActionPlaces;
-import com.intellij.openapi.actionSystem.ActionToolbarPosition;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.actionSystem.DataProvider;
-import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.editor.impl.DocumentImpl;
-import com.intellij.openapi.fileTypes.FileType;
-import com.intellij.openapi.fileTypes.LanguageFileType;
-import com.intellij.openapi.util.SystemInfo;
-import com.intellij.ui.AnActionButton;
-import com.intellij.ui.AnActionButtonRunnable;
-import com.intellij.ui.CaptionPanel;
 import com.intellij.ui.JBColor;
-import com.intellij.ui.ToolbarDecorator;
-import com.intellij.ui.border.CustomLineBorder;
-import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
-import com.intellij.util.ui.UIUtil;
-import com.intellij.util.ui.tree.TreeUtil;
-import com.intellij.xdebugger.XDebuggerBundle;
-import com.intellij.xdebugger.XExpression;
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint;
 import com.intellij.xdebugger.breakpoints.ui.XBreakpointCustomPropertiesPanel;
-import com.intellij.xdebugger.evaluation.EvaluationMode;
-import com.intellij.xdebugger.evaluation.XDebuggerEditorsProvider;
-import com.intellij.xdebugger.impl.XDebuggerUtilImpl;
-import com.intellij.xdebugger.impl.actions.XDebuggerActions;
 import com.intellij.xdebugger.impl.breakpoints.XBreakpointBase;
-import com.intellij.xdebugger.impl.breakpoints.XBreakpointUtil;
-import com.intellij.xdebugger.impl.frame.XWatchesView;
-import com.intellij.xdebugger.impl.ui.DebuggerUIUtil;
-import com.intellij.xdebugger.impl.ui.XDebuggerExpressionComboBox;
-import com.intellij.xdebugger.impl.ui.tree.XDebuggerTreePanel;
-import com.intellij.xdebugger.impl.ui.tree.nodes.WatchNode;
-import com.intellij.xdebugger.impl.ui.tree.nodes.WatchesRootNode;
-import com.intellij.xdebugger.impl.ui.tree.nodes.XDebuggerTreeNode;
 
-import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.HierarchyEvent;
-import java.awt.event.HierarchyListener;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.swing.JComponent;
 import javax.swing.JPanel;
-import javax.swing.JRootPane;
-import javax.swing.JSeparator;
-import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
-import javax.swing.event.AncestorEvent;
-import javax.swing.event.AncestorListener;
 
 /**
  * The breakpoint config panel is shown for both the config popup (right click on a breakpoint) and in the full

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
@@ -377,7 +377,9 @@ public class CloudAttachDialog extends DialogWrapper {
     }
 
     final ChangeListManager changeListManager = ChangeListManager.getInstance(project);
-    if (changeListManager.isFreezedWithNotification("Can not stash changes now")) return false;
+    if (changeListManager.isFreezedWithNotification("Can not stash changes now")) {
+      return false;
+    }
 
     final GitLineHandler handler = new GitLineHandler(project, sourceRepository.getRoot(), GitCommand.STASH);
     handler.addParameters("save");

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/elysium/ProjectSelectorCredentialedUser.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/elysium/ProjectSelectorCredentialedUser.java
@@ -17,7 +17,6 @@ package com.google.gct.idea.elysium;
 
 import com.intellij.ui.components.JBLabel;
 import com.intellij.util.containers.hash.HashMap;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/settings/ExportSettings.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/settings/ExportSettings.java
@@ -65,13 +65,15 @@ public class ExportSettings {
         final int ret = Messages
           .showOkCancelDialog(IdeBundle.message("prompt.overwrite.settings.file", FileUtil.toSystemDependentName(saveFile.getPath())),
                               IdeBundle.message("title.file.already.exists"), Messages.getWarningIcon());
-        if (ret != Messages.OK) return;
+        if (ret != Messages.OK) {
+          return;
+        }
       }
 
       final JarOutputStream output = new JarOutputStream(new FileOutputStream(saveFile));
       try {
         final File configPath = new File(PathManager.getConfigPath());
-        final HashSet<String> writtenItemRelativePaths = new HashSet<String>();
+        final Set<String> writtenItemRelativePaths = new HashSet<String>();
         for (File file : exportFiles) {
           final String rPath = FileUtil.getRelativePath(configPath, file);
           assert rPath != null;
@@ -98,7 +100,7 @@ public class ExportSettings {
 
   }
 
-  private static void exportInstalledPlugins(File saveFile, JarOutputStream output, HashSet<String> writtenItemRelativePaths) throws IOException {
+  private static void exportInstalledPlugins(File saveFile, JarOutputStream output, Set<String> writtenItemRelativePaths) throws IOException {
     final List<String> oldPlugins = new ArrayList<String>();
     for (IdeaPluginDescriptor descriptor : PluginManagerCore.getPlugins()) {
       if (!descriptor.isBundled() && descriptor.isEnabled()) {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/settings/ImportSettings.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/settings/ImportSettings.java
@@ -15,14 +15,11 @@
  */
 package com.google.gct.idea.settings;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gct.idea.util.GctBundle;
 import com.intellij.ide.IdeBundle;
 import com.intellij.ide.actions.ImportSettingsFilenameFilter;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.ide.startup.StartupActionScriptManager;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ApplicationNamesInfo;
 import com.intellij.openapi.application.PathManager;
@@ -72,7 +69,7 @@ public class ImportSettings {
         return;
       }
 
-      final ArrayList<ExportableComponent> registeredComponents = new ArrayList<ExportableComponent>(
+      final List<ExportableComponent> registeredComponents = new ArrayList<ExportableComponent>(
         Arrays.asList(ApplicationManager.getApplication().getComponents(ExportableApplicationComponent.class)));
       registeredComponents.addAll(ServiceBean.loadServicesFromBeans(ExportableComponent.EXTENSION_POINT, ExportableComponent.class));
 
@@ -142,18 +139,20 @@ public class ImportSettings {
   }
 
   private static List<ExportableComponent> getComponentsStored(File zipFile,
-    ArrayList<ExportableComponent> registeredComponents)
+    List<ExportableComponent> registeredComponents)
     throws IOException {
     final File configPath = new File(PathManager.getConfigPath());
 
-    final ArrayList<ExportableComponent> components = new ArrayList<ExportableComponent>();
+    final List<ExportableComponent> components = new ArrayList<ExportableComponent>();
     for (ExportableComponent component : registeredComponents) {
       final File[] exportFiles = component.getExportFiles();
       for (File exportFile : exportFiles) {
         final String rPath = FileUtil.getRelativePath(configPath, exportFile);
         assert rPath != null;
         String relativePath = FileUtil.toSystemIndependentName(rPath);
-        if (exportFile.isDirectory()) relativePath += "/";
+        if (exportFile.isDirectory()) {
+          relativePath += "/";
+        }
         if (ZipUtil.isZipContainsEntry(zipFile, relativePath)) {
           components.add(component);
           break;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/ui/GoogleCloudToolsIcons.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/ui/GoogleCloudToolsIcons.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.util.IconLoader;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import javax.swing.Icon;


### PR DESCRIPTION
#241.

1. First add 'custom-pmd-rule.xml' to use a custom PMD rules instead of the Gradle PMD plugin default. This was to exclude the UselessParentheses rule which somewhat conflicts with the Google style guide where parentheses are often encouraged.

2. Add one more redundant null check exclusion in the FindBugs configuration.

3. The rest are PMD suggestions.
