### PR TITLE
Address NullPointerException FindBugs warning instances

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/EndpointUtilities.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/EndpointUtilities.java
@@ -75,6 +75,7 @@ public class EndpointUtilities {
    */
   public static boolean isApiMethod(@NonNls PsiMethod psiMethod) {
     PsiModifierList psiModifierList =  psiMethod.getModifierList();
+    assert psiModifierList != null;
     if(psiModifierList.hasModifierProperty(PsiModifier.PUBLIC) &&
        !psiModifierList.hasModifierProperty(PsiModifier.STATIC)) {
       return true;
@@ -99,6 +100,7 @@ public class EndpointUtilities {
     }
 
     PsiModifierList modifierList = method.getModifierList();
+    assert modifierList != null;
     if(modifierList.hasModifierProperty(PsiModifier.PUBLIC)) {
       return true;
     }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNamespaceInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ApiNamespaceInspection.java
@@ -98,8 +98,11 @@ public class ApiNamespaceInspection extends EndpointInspectionBase{
         String ownerName =
           EndpointUtilities.removeBeginningAndEndingQuotes(ownerNameWithQuotes);
         // Package Path has a default value of ""
+        PsiAnnotationMemberValue pathAttributeValue =
+          annotation.findAttributeValue(API_NAMESPACE_PACKAGE_PATH_ATTRIBUTE);
+        assert pathAttributeValue != null;
         String packagePath = EndpointUtilities.removeBeginningAndEndingQuotes(
-          annotation.findAttributeValue(API_NAMESPACE_PACKAGE_PATH_ATTRIBUTE).getText());
+          pathAttributeValue.getText());
 
         boolean allUnspecified =
           ownerDomain.isEmpty() && ownerName.isEmpty() && packagePath.isEmpty();

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/FullJavaNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/FullJavaNameInspection.java
@@ -97,14 +97,18 @@ public class FullJavaNameInspection extends EndpointInspectionBase {
           return;
         }
 
-        String javaName = psiMethod.getContainingClass().getQualifiedName() + "." + psiMethod.getName();
+        PsiClass psiContainingClass = psiMethod.getContainingClass();
+        assert psiContainingClass != null;
+        String javaName = psiContainingClass.getQualifiedName() + "." + psiMethod.getName();
         PsiMethod seenMethod = javaMethodNames.get(javaName);
         if (seenMethod == null) {
           javaMethodNames.put(javaName, psiMethod);
         } else {
-          String psiMethodName = psiMethod.getContainingClass().getName() + "." + psiMethod.getName() +
+          String psiMethodName = psiContainingClass.getName() + "." + psiMethod.getName() +
             psiMethod.getParameterList().getText();
-          String seenMethodName = seenMethod.getContainingClass().getName() + "." + seenMethod.getName() +
+          PsiClass seenContainingClass = seenMethod.getContainingClass();
+          assert seenContainingClass != null;
+          String seenMethodName = seenContainingClass.getName() + "." + seenMethod.getName() +
             seenMethod.getParameterList().getText();
           holder.registerProblem(psiMethod, "Overloaded methods are not supported. " +  javaName +
             " has at least one overload: " + psiMethodName + " and " + seenMethodName,

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/FullMethodNameInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/FullMethodNameInspection.java
@@ -103,6 +103,7 @@ public class FullMethodNameInspection extends EndpointInspectionBase  {
 
         // Get @ApiMethod's name attribute
         PsiModifierList modifierList = psiMethod.getModifierList();
+        assert modifierList != null;
         PsiAnnotation apiMethodAnnotation = modifierList.findAnnotation(GctConstants.APP_ENGINE_ANNOTATION_API_METHOD);
         if(apiMethodAnnotation == null) {
           return;

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/InvalidParameterAnnotationsInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/InvalidParameterAnnotationsInspection.java
@@ -86,13 +86,16 @@ public class InvalidParameterAnnotationsInspection extends EndpointInspectionBas
         }
 
         // Check for @ApiMethod
-        PsiAnnotation apiMethodAnnotation = method.getModifierList().findAnnotation(GctConstants.APP_ENGINE_ANNOTATION_API_METHOD);
+        PsiModifierList methodModifierList = method.getModifierList();
+        assert methodModifierList != null;
+        PsiAnnotation apiMethodAnnotation = methodModifierList.findAnnotation(GctConstants.APP_ENGINE_ANNOTATION_API_METHOD);
         if(apiMethodAnnotation == null) {
           return;
         }
 
         // path has a default value of ""
         PsiAnnotationMemberValue pathMember = apiMethodAnnotation.findAttributeValue("path");
+        assert pathMember != null;
         String path = EndpointUtilities.removeBeginningAndEndingQuotes(pathMember.getText());
 
         // Check for path parameter, @ApiMethod(path="xys/{xy}")
@@ -116,9 +119,11 @@ public class InvalidParameterAnnotationsInspection extends EndpointInspectionBas
           }
 
           // Check if @Named parameter also has @Nullable or @DefaultValue
-          if((aParameter.getModifierList().findAnnotation(GctConstants.APP_ENGINE_ANNOTATION_NULLABLE) != null)||
-             (aParameter.getModifierList().findAnnotation("javax.annotation.Nullable") != null) ||
-             (aParameter.getModifierList().findAnnotation(GctConstants.APP_ENGINE_ANNOTATION_DEFAULT_VALUE) != null)) {
+          PsiModifierList parameterModifierList = aParameter.getModifierList();
+          assert parameterModifierList != null;
+          if((parameterModifierList.findAnnotation(GctConstants.APP_ENGINE_ANNOTATION_NULLABLE) != null) ||
+             (parameterModifierList.findAnnotation("javax.annotation.Nullable") != null) ||
+             (parameterModifierList.findAnnotation(GctConstants.APP_ENGINE_ANNOTATION_DEFAULT_VALUE) != null)) {
             holder.registerProblem(aParameter, "Invalid parameter configuration. " +
               "A parameter in the method path should not be marked @Nullable or @DefaultValue.",
               new MyQuickFix());
@@ -181,6 +186,7 @@ public class InvalidParameterAnnotationsInspection extends EndpointInspectionBas
       }
 
       PsiModifierList modifierList = ((PsiParameter)element).getModifierList();
+      assert modifierList != null;
       PsiAnnotation gaeNullableAnnotation = modifierList.findAnnotation(GctConstants.APP_ENGINE_ANNOTATION_NULLABLE);
       if(gaeNullableAnnotation != null){
         gaeNullableAnnotation.delete();

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ResourceParameterInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/ResourceParameterInspection.java
@@ -125,6 +125,7 @@ public class ResourceParameterInspection extends EndpointInspectionBase {
 
         // Check that parameter does not have an @Named annotation
         PsiModifierList modifierList = psiParameter.getModifierList();
+        assert modifierList != null;
         PsiAnnotation annotation = modifierList.findAnnotation("javax.inject.Named");
         if(annotation == null) {
           annotation = modifierList.findAnnotation(GctConstants.APP_ENGINE_ANNOTATION_NAMED );

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/RestSignatureInspection.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/validation/RestSignatureInspection.java
@@ -96,6 +96,7 @@ public class RestSignatureInspection extends EndpointInspectionBase {
       @Override
       public String guessResourceName(PsiMethod method) {
         String methodName = method.getName();
+        assert methodName != null;
         return methodNamePrefix.length() >= methodName.length() ? null :
                methodName.substring(methodNamePrefix.length()).toLowerCase();
       }
@@ -110,6 +111,7 @@ public class RestSignatureInspection extends EndpointInspectionBase {
       @Override
       public String guessResourceName(PsiMethod method) {
         String methodName = method.getName();
+        assert methodName != null;
         return methodNamePrefix.length() >= methodName.length() ? null :
                methodName.substring(methodNamePrefix.length()).toLowerCase();
       }
@@ -291,6 +293,7 @@ public class RestSignatureInspection extends EndpointInspectionBase {
    */
   public String getHttpMethod(PsiMethod psiMethod) {
     PsiModifierList modifierList = psiMethod.getModifierList();
+    assert modifierList != null;
     String httpMethod = null;
 
     // Check if the httpMethod was specified by uses in @ApiMethod's httpMethod attribute
@@ -321,6 +324,7 @@ public class RestSignatureInspection extends EndpointInspectionBase {
    */
   public String getPath(PsiMethod psiMethod) {
     PsiModifierList modifierList = psiMethod.getModifierList();
+    assert modifierList != null;
     String path = null;
 
     // Check if the httpMethod was specified by user in @ApiMethod's httpMethod attribute
@@ -396,6 +400,7 @@ public class RestSignatureInspection extends EndpointInspectionBase {
   @Nullable
   private String getResourceProperty(PsiMethod psiMethod) {
     PsiClass psiClass = psiMethod.getContainingClass();
+    assert psiClass != null;
     PsiModifierList modifierList = psiClass.getModifierList();
     String resource = null;
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebuggerRunner.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebuggerRunner.java
@@ -114,11 +114,11 @@ public class CloudDebuggerRunner extends DefaultProgramRunner {
               throw new RunCanceledByUserException();
             }
 
-            if (environment.getRunnerAndConfigurationSettings() != null &&
-                environment.getRunnerAndConfigurationSettings()
-                    .getConfiguration() instanceof CloudDebugRunConfiguration) {
+            RunnerAndConfigurationSettings runnerAndConfig = environment.getRunnerAndConfigurationSettings();
+            if (runnerAndConfig != null &&
+                runnerAndConfig.getConfiguration() instanceof CloudDebugRunConfiguration) {
               CloudDebugRunConfiguration config =
-                  (CloudDebugRunConfiguration) environment.getRunnerAndConfigurationSettings().getConfiguration();
+                  (CloudDebugRunConfiguration) runnerAndConfig.getConfiguration();
               // State is only stored in the run config between active sessions.
               // Otherwise, the background watcher may hit a check during debug session startup.
               config.setProcessState(null);

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudLineBreakpointType.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudLineBreakpointType.java
@@ -28,6 +28,7 @@ import com.intellij.debugger.ui.breakpoints.Breakpoint;
 import com.intellij.debugger.ui.breakpoints.JavaBreakpointType;
 import com.intellij.debugger.ui.breakpoints.LineBreakpoint;
 import com.intellij.execution.impl.RunManagerImpl;
+import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -86,8 +87,9 @@ public class CloudLineBreakpointType extends XLineBreakpointType<CloudLineBreakp
   @Override
   public final boolean canPutAt(@NotNull final VirtualFile file, final int line, @NotNull Project project) {
     RunManagerImpl runManager = RunManagerImpl.getInstanceImpl(project);
-    if (runManager.getSelectedConfiguration() == null ||
-        !(runManager.getSelectedConfiguration().getConfiguration() instanceof CloudDebugRunConfiguration)) {
+    RunnerAndConfigurationSettings runnerAndConfig = runManager.getSelectedConfiguration();
+    if (runnerAndConfig == null ||
+        !(runnerAndConfig.getConfiguration() instanceof CloudDebugRunConfiguration)) {
       return false;
     }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/actions/ToggleSnapshotLocationAction.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/actions/ToggleSnapshotLocationAction.java
@@ -61,13 +61,14 @@ public class ToggleSnapshotLocationAction extends AnAction {
         LOG.error("could not add a snapshot location as the target editor was unexpectedly null.");
         return;
       }
-      if (editor.getUserData(POPUP_LINE) == null) {
+      Integer popUpLine = editor.getUserData(POPUP_LINE);
+      if (popUpLine == null) {
         LOG.error("could not add a snapshot location as the target line was unexpectedly null.");
         return;
       }
       XDebuggerUtil.getInstance()
         .toggleLineBreakpoint(exEditor.getProject(), CloudLineBreakpointType.getInstance(), exEditor.getVirtualFile(),
-                              editor.getUserData(POPUP_LINE));
+                              popUpLine);
     }
   }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/BreakpointConfigurationPanel.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/BreakpointConfigurationPanel.java
@@ -44,6 +44,7 @@ import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ui.UIUtil;
 import com.intellij.util.ui.tree.TreeUtil;
 import com.intellij.xdebugger.XExpression;
+import com.intellij.xdebugger.XSourcePosition;
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint;
 import com.intellij.xdebugger.breakpoints.ui.XBreakpointCustomPropertiesPanel;
 import com.intellij.xdebugger.evaluation.EvaluationMode;
@@ -229,19 +230,23 @@ public class BreakpointConfigurationPanel
 
      if (rootNode != null && lineBreakpointImpl != null) {
       List<String> expressionsToSave = new ArrayList<String>();
-      for (WatchNode node : rootNode.getAllChildren()) {
-        expressionsToSave.add(node.getExpression().getExpression());
-      }
-      if (properties.setWatchExpressions(expressionsToSave.toArray(new String[expressionsToSave.size()]))) {
-        lineBreakpointImpl.fireBreakpointChanged();
+      List<? extends WatchNode> children = rootNode.getAllChildren();
+      if (children != null) {
+        for (WatchNode node : children) {
+          expressionsToSave.add(node.getExpression().getExpression());
+        }
+        if (properties.setWatchExpressions(expressionsToSave.toArray(new String[expressionsToSave.size()]))) {
+          lineBreakpointImpl.fireBreakpointChanged();
+        }
       }
     }
   }
 
   @Nullable
   private static Language getFileTypeLanguage(XLineBreakpoint<CloudLineBreakpointProperties> breakpoint) {
-    if (breakpoint.getSourcePosition() != null) {
-      FileType fileType = breakpoint.getSourcePosition().getFile().getFileType();
+    XSourcePosition sourcePosition = breakpoint.getSourcePosition();
+    if (sourcePosition != null) {
+      FileType fileType = sourcePosition.getFile().getFileType();
       if (fileType instanceof LanguageFileType) {
         return ((LanguageFileType)fileType).getLanguage();
       }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/CloudAttachDialog.java
@@ -64,6 +64,7 @@ import git4idea.branch.GitBrancher;
 import git4idea.commands.GitCommand;
 import git4idea.commands.GitHandlerUtil;
 import git4idea.commands.GitLineHandler;
+import git4idea.GitLocalBranch;
 import git4idea.i18n.GitBundle;
 import git4idea.repo.GitRepository;
 
@@ -286,12 +287,13 @@ public class CloudAttachDialog extends DialogWrapper {
     warningMessage.setVisible(false);
     checkBackgroundSessions();
 
+    String targetSyncSHA = syncResult.getTargetSyncSHA();
     if (syncResult.needsStash() && syncResult.needsSync()) {
       setOkText(false);
       syncStashCheckbox.setVisible(true);
-      assert syncResult.getTargetSyncSHA() != null;
+      assert targetSyncSHA != null;
       syncStashCheckbox.setText(
-          GctBundle.getString("clouddebug.stash.local.changes.and.sync", syncResult.getTargetSyncSHA().substring(0, 7)));
+          GctBundle.getString("clouddebug.stash.local.changes.and.sync", targetSyncSHA.substring(0, 7)));
       syncStashCheckbox.setSelected(true);
     }
     else if (syncResult.needsStash()) {
@@ -300,7 +302,7 @@ public class CloudAttachDialog extends DialogWrapper {
       syncStashCheckbox.setText(GctBundle.getString("clouddebug.stashbuttontext"));
       syncStashCheckbox.setSelected(true);
     }
-    else if (syncResult.needsSync() && syncResult.getTargetSyncSHA() == null) {
+    else if (syncResult.needsSync() && targetSyncSHA == null) {
       setOkText(true);
       warningHeader.setVisible(true);
       warningMessage.setVisible(true);
@@ -309,8 +311,8 @@ public class CloudAttachDialog extends DialogWrapper {
     else if (syncResult.needsSync()) {
       setOkText(false);
       syncStashCheckbox.setVisible(true);
-      assert syncResult.getTargetSyncSHA() != null;
-      syncStashCheckbox.setText("Sync to " + syncResult.getTargetSyncSHA().substring(0, 7));
+      assert targetSyncSHA != null;
+      syncStashCheckbox.setText("Sync to " + targetSyncSHA.substring(0, 7));
       syncStashCheckbox.setSelected(true);
     }
     else if (!syncResult.hasRemoteRepository()) {
@@ -411,8 +413,9 @@ public class CloudAttachDialog extends DialogWrapper {
     sourceRepository = syncResult.getLocalRepository();
 
     if (syncResult.needsStash() || syncResult.needsSync()) {
-      if (sourceRepository.getCurrentBranch() != null) {
-        originalBranchName = sourceRepository.getCurrentBranch().getName();
+      GitLocalBranch currentBranch = sourceRepository.getCurrentBranch();
+      if (currentBranch != null) {
+        originalBranchName = currentBranch.getName();
       }
       else {
         originalBranchName = sourceRepository.getCurrentRevision();

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/ProjectDebuggeeBinding.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/ProjectDebuggeeBinding.java
@@ -148,8 +148,9 @@ class ProjectDebuggeeBinding {
       @Override
       public void run() {
         try {
-          if (projectSelector.getProjectNumber() != null && getCloudDebuggerClient() != null) {
-            final ListDebuggeesResponse debuggees = getCloudDebuggerClient().debuggees().list()
+          Debugger debugger = getCloudDebuggerClient();
+          if (projectSelector.getProjectNumber() != null && debugger != null) {
+            final ListDebuggeesResponse debuggees = debugger.debuggees().list()
                 .setProject(projectSelector.getProjectNumber().toString())
                 .execute();
             isCdbQueried = true;
@@ -182,8 +183,9 @@ class ProjectDebuggeeBinding {
                       }
                       perModuleCache.put(key, item);
                     }
-                    if (inputState != null && !Strings.isNullOrEmpty(inputState.getDebuggeeId())) {
-                      if (inputState.getDebuggeeId().equals(item.getId())) { // NOPMD
+                    String debuggeeId = inputState.getDebuggeeId();
+                    if (inputState != null && !Strings.isNullOrEmpty(debuggeeId)) {
+                      if (debuggeeId.equals(item.getId())) { // NOPMD
                         targetSelection = item;
                       }
                     }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/elysium/SelectUserDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/elysium/SelectUserDialog.java
@@ -18,6 +18,7 @@ package com.google.gct.idea.elysium;
 import com.google.api.client.repackaged.com.google.common.base.Strings;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gct.idea.util.GctBundle;
+import com.google.gct.login.CredentialedUser;
 import com.google.gct.login.IntellijGoogleLoginService;
 
 import com.intellij.openapi.project.Project;
@@ -69,7 +70,8 @@ public class SelectUserDialog extends DialogWrapper {
     if (!Strings.isNullOrEmpty(selectedUser)) {
       return selectedUser;
     }
-    return login.getSelectedUser() != null ? login.getSelectedUser().getEmail() : "";
+    CredentialedUser credUser = login.getSelectedUser();
+    return credUser != null ? credUser.getEmail() : "";
   }
 
   @VisibleForTesting

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/elysium/UserSelector.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/elysium/UserSelector.java
@@ -208,8 +208,9 @@ public class UserSelector extends CustomizableComboBox implements CustomizableCo
             @SuppressWarnings("ConstantConditions") // This suppresses a nullref warning for GoogleLogin.getInstance().getActiveUser().
             @Override
             public void run() {
-              if (Services.getLoginService().getActiveUser() != null) {
-                UserSelector.this.setText(Services.getLoginService().getActiveUser().getEmail());
+              CredentialedUser activeUser = Services.getLoginService().getActiveUser();
+              if (activeUser != null) {
+                UserSelector.this.setText(activeUser.getEmail());
               }
             }
           });

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/git/GcpCheckoutProvider.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/git/GcpCheckoutProvider.java
@@ -69,14 +69,17 @@ public class GcpCheckoutProvider implements CheckoutProvider {
     BasicAction.saveAll();
     CloneGcpDialog dialog = new CloneGcpDialog(project);
     DialogManager.show(dialog);
+    final String sourceRepositoryURL = dialog.getSourceRepositoryURL();
+    final String directoryName = dialog.getDirectoryName();
+    final String parentDirectory = dialog.getParentDirectory();
     if (!dialog.isOK() ||
-      Strings.isNullOrEmpty(dialog.getParentDirectory()) ||
-      Strings.isNullOrEmpty(dialog.getSourceRepositoryURL()) ||
-      Strings.isNullOrEmpty(dialog.getDirectoryName())) {
+      Strings.isNullOrEmpty(parentDirectory) ||
+      Strings.isNullOrEmpty(sourceRepositoryURL) ||
+      Strings.isNullOrEmpty(directoryName)) {
       return;
     }
     final LocalFileSystem lfs = LocalFileSystem.getInstance();
-    final File parent = new File(dialog.getParentDirectory());
+    final File parent = new File(parentDirectory);
     VirtualFile destinationParent = lfs.findFileByIoFile(parent);
     if (destinationParent == null) {
       destinationParent = lfs.refreshAndFindFileByIoFile(parent);
@@ -84,9 +87,6 @@ public class GcpCheckoutProvider implements CheckoutProvider {
     if (destinationParent == null) {
       return;
     }
-    final String sourceRepositoryURL = dialog.getSourceRepositoryURL();
-    final String directoryName = dialog.getDirectoryName();
-    final String parentDirectory = dialog.getParentDirectory();
     final String gcpUserName = dialog.getGCPUserName();
     if (Strings.isNullOrEmpty(gcpUserName)) {
       LOG.error("unexpected blank username during checkout");


### PR DESCRIPTION
#241.

Here is my take on addressing NPE warnings that FindBugs reports.

1. I learned that I can use 'assert' to mute a warning case. Some cases were muted simply this way.
2. Some warnings can be avoided by simple syntactic restructuring of code.
3. For a couple of cases, I really inserted a null check.

For 1 and 2, it is my own logical conclusion that those cases don't need an explicit null check. I can't say I am 100% confident though. I also believe that the simple syntactic substitution doesn't change the semantics (i.e., I assume function calls are 'const').

After this PR, we would have exactly one FindBug warning instance and one PMD warning instance, which we need to look into together.