### PR TITLE
changing listener mechanism and marking fields transient

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmDeploymentRunConfigurationEditor.java
@@ -17,7 +17,6 @@
 package com.google.gct.idea.appengine.cloud;
 
 import com.google.common.base.Supplier;
-import com.google.common.eventbus.Subscribe;
 import com.google.gct.idea.appengine.cloud.ManagedVmCloudType.ManagedVmDeploymentConfigurator.UserSpecifiedPathDeploymentSource;
 import com.google.gct.idea.appengine.cloud.ManagedVmDeploymentConfiguration.ConfigType;
 import com.google.gct.idea.util.GctBundle;
@@ -41,6 +40,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 
@@ -82,7 +83,7 @@ public class ManagedVmDeploymentRunConfigurationEditor extends
     this.appEngineHelper = appEngineHelper;
 
     updateCloudProjectName(appEngineHelper.getProjectId());
-    configuration.getProjectNameListener().register(new ProjectNameListener());
+    configuration.setProjectNameListener(new ProjectNameListener());
 
     updateJarWarSelector();
     userSpecifiedArtifactFileSelector.setVisible(true);
@@ -265,10 +266,10 @@ public class ManagedVmDeploymentRunConfigurationEditor extends
     }
   }
 
-  private class ProjectNameListener {
-    @Subscribe
-    public void handleProjectNameChange(String name) {
-      updateCloudProjectName(name);
+  private class ProjectNameListener implements PropertyChangeListener {
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+      updateCloudProjectName((String) evt.getNewValue());
     }
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmServerConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmServerConfiguration.java
@@ -16,10 +16,12 @@
 
 package com.google.gct.idea.appengine.cloud;
 
-import com.google.common.eventbus.EventBus;
-
 import com.intellij.remoteServer.configuration.ServerConfigurationBase;
 import com.intellij.util.xmlb.annotations.Attribute;
+import com.intellij.util.xmlb.annotations.Transient;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 
 /**
  * Model for the IntelliJ application scoped 'Cloud' configurations.  This is a base configuration
@@ -33,7 +35,8 @@ public class ManagedVmServerConfiguration extends
   private String cloudProjectName;
   private String googleUserName;
 
-  private EventBus projectNameListener = new EventBus();
+  @Transient
+  private PropertyChangeListener projectNameListener;
 
   @Attribute("cloudSdkExecutablePath")
   public String getCloudSdkExecutablePath() {
@@ -50,9 +53,10 @@ public class ManagedVmServerConfiguration extends
   }
 
   public void setCloudProjectName(String cloudProjectName) {
+    fireNameChangeEvent(this.cloudProjectName, cloudProjectName);
     this.cloudProjectName = cloudProjectName;
-    projectNameListener.post(cloudProjectName);
   }
+
 
   @Attribute("googleUserName")
   public String getGoogleUserName() {
@@ -63,7 +67,18 @@ public class ManagedVmServerConfiguration extends
     this.googleUserName = googleUserName;
   }
 
-  protected EventBus getProjectNameListener() {
-    return projectNameListener;
+  protected void setProjectNameListener(PropertyChangeListener listener) {
+    this.projectNameListener = listener;
+  }
+
+  protected void fireNameChangeEvent(String oldName, String newName) {
+    if (projectNameListener != null) {
+      projectNameListener.propertyChange(new PropertyChangeEvent(
+          this,
+          "cloudProjectName",
+          oldName,
+          newName
+      ));
+    }
   }
 }


### PR DESCRIPTION
fixes #531 

Also forces there to be only a single project name change listener (before multiple could have been registered). Also uses a more appropriate listener mechanism.