### PR TITLE
User must select Cloud SDK home path, not /bin

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -20,7 +20,7 @@ cloud.project.label=Project\:
 
 appengine.cloudsdk.location.label=Cloud SDK directory\:
 appengine.cloudsdk.location.browse.window.title=Browse to Cloud SDK directory
-appengine.cloudsdk.location.missing.message=Please select a Cloud SDK directory.
+appengine.cloudsdk.location.missing.message=Please select a Cloud SDK home directory.
 appengine.cloudsdk.project.missing.message=Please select a project.
 appengine.appyaml.location.browse.window.title=Browse for Your App.Yaml Location
 appengine.managedvm.name=App Engine Flexible Environment

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurable.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurable.java
@@ -64,13 +64,11 @@ public class ManagedVmCloudConfigurable extends RemoteServerConfigurable impleme
 
     warningMessage.setVisible(false);
 
-    final String cloudSdkExecutablePath = CloudSdkUtil.findCloudSdkExecutablePath(environmentProvider);
     final String cloudSdkDirectoryPath = CloudSdkUtil.findCloudSdkDirectoryPath(environmentProvider);
 
-    if (cloudSdkExecutablePath != null
-        && cloudSdkDirectoryPath != null
-        && configuration.getCloudSdkExecutablePath() == null) {
-      configuration.setCloudSdkExecutablePath(cloudSdkExecutablePath);
+    if (cloudSdkDirectoryPath != null
+        && configuration.getCloudSdkHomePath() == null) {
+      configuration.setCloudSdkHomePath(cloudSdkDirectoryPath);
       cloudSdkDirectoryField.setText(cloudSdkDirectoryPath);
     }
 
@@ -140,7 +138,7 @@ public class ManagedVmCloudConfigurable extends RemoteServerConfigurable impleme
   @Override
   public boolean isModified() {
     boolean isSdkDirModified = !Comparing.strEqual(getCloudSdkDirectory(),
-        CloudSdkUtil.toParentDirectory(configuration.getCloudSdkExecutablePath()));
+        configuration.getCloudSdkHomePath());
     boolean isProjectModified = !Comparing.strEqual(getCloudProjectName(),
         configuration.getCloudProjectName());
     boolean isUserModified = !Comparing.strEqual(getGoogleUserName(),
@@ -166,15 +164,13 @@ public class ManagedVmCloudConfigurable extends RemoteServerConfigurable impleme
       if (selectedUser != null) {
         configuration.setGoogleUserName(selectedUser.getEmail());
       }
-      configuration.setCloudSdkExecutablePath(
-          CloudSdkUtil.toExecutablePath(cloudSdkDirectoryField.getText()));
+      configuration.setCloudSdkHomePath(cloudSdkDirectoryField.getText());
     }
   }
 
   @Override
   public void reset() {
-    cloudSdkDirectoryField.setText(
-        CloudSdkUtil.toParentDirectory(configuration.getCloudSdkExecutablePath()));
+    cloudSdkDirectoryField.setText(configuration.getCloudSdkHomePath());
     projectSelector.setText(configuration.getCloudProjectName());
   }
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudType.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudType.java
@@ -159,7 +159,7 @@ public class ManagedVmCloudType extends ServerType<ManagedVmServerConfiguration>
       return new ManagedVmDeploymentRunConfigurationEditor(project, source,
           server.getConfiguration(),
           new CloudSdkAppEngineHelper(
-              new File(server.getConfiguration().getCloudSdkExecutablePath()),
+              new File(CloudSdkUtil.toExecutablePath(server.getConfiguration().getCloudSdkHomePath())),
               server.getConfiguration().getCloudProjectName(),
               server.getConfiguration().getGoogleUserName()));
     }
@@ -211,7 +211,7 @@ public class ManagedVmCloudType extends ServerType<ManagedVmServerConfiguration>
 
     @Override
     public void connect(@NotNull ConnectionCallback<ManagedVmDeploymentConfiguration> callback) {
-      if (CloudSdkUtil.isCloudSdkExecutable(configuration.getCloudSdkExecutablePath())) {
+      if (CloudSdkUtil.isCloudSdkExecutable(CloudSdkUtil.toExecutablePath(configuration.getCloudSdkHomePath()))) {
         callback.connected(new ManagedVmRuntimeInstance(configuration));
       } else {
         callback.errorOccurred(GctBundle.message("appengine.deployment.error.invalid.cloudsdk"));
@@ -240,7 +240,7 @@ public class ManagedVmCloudType extends ServerType<ManagedVmServerConfiguration>
         return;
       }
       AppEngineHelper appEngineHelper = new CloudSdkAppEngineHelper(
-          getFileFromFilePath(configuration.getCloudSdkExecutablePath()),
+          getFileFromFilePath(CloudSdkUtil.toExecutablePath(configuration.getCloudSdkHomePath())),
           configuration.getCloudProjectName(),
           configuration.getGoogleUserName());
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmServerConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmServerConfiguration.java
@@ -31,16 +31,16 @@ import java.beans.PropertyChangeListener;
 public class ManagedVmServerConfiguration extends
     ServerConfigurationBase<ManagedVmServerConfiguration> {
 
-  private String cloudSdkExecutablePath;
+  private String cloudSdkHomePath;
   private String cloudProjectName;
   private String googleUserName;
 
   @Transient
   private PropertyChangeListener projectNameListener;
 
-  @Attribute("cloudSdkExecutablePath")
-  public String getCloudSdkExecutablePath() {
-    return cloudSdkExecutablePath;
+  @Attribute("cloudSdkHomePath")
+  public String getCloudSdkHomePath() {
+    return cloudSdkHomePath;
   }
 
   @Attribute("cloudProjectName")
@@ -48,8 +48,8 @@ public class ManagedVmServerConfiguration extends
     return cloudProjectName;
   }
 
-  public void setCloudSdkExecutablePath(String cloudSdkExecutablePath) {
-    this.cloudSdkExecutablePath = cloudSdkExecutablePath;
+  public void setCloudSdkHomePath(String cloudSdkHomePath) {
+    this.cloudSdkHomePath = cloudSdkHomePath;
   }
 
   public void setCloudProjectName(String cloudProjectName) {

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/CloudSdkUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/util/CloudSdkUtil.java
@@ -54,7 +54,7 @@ public final class CloudSdkUtil {
   }
 
   /**
-   * Finds the path to the Cloud SDK binary parent directory on the local file system.
+   * Finds the path to the Cloud SDK home directory on the local file system.
    *
    * @return a {@link String} path to the Cloud SDK directory or {@code null}
    * if it could not be found.
@@ -63,14 +63,14 @@ public final class CloudSdkUtil {
   public static String findCloudSdkDirectoryPath(
       @NotNull SystemEnvironmentProvider environmentProvider) {
     File cloudSdkExecutable = findCloudSdkExecutable(environmentProvider);
-    return cloudSdkExecutable != null ? cloudSdkExecutable.getParent() : null;
+    return cloudSdkExecutable != null ? toSdkHomeDirectory(cloudSdkExecutable.getPath()) : null;
   }
 
   /**
    * Checks if an appropriately named binary exists on the local file system for the given
-   * parent directory path.
+   * SDK home directory path.
    *
-   * @param path @link String} to Cloud SDK binary parent directory on local file system.
+   * @param path @link String} to Cloud SDK home directory on local file system.
    * @return a boolean indicating if the file was found.
    */
   public static boolean containsCloudSdkExecutable(String path) {
@@ -93,12 +93,12 @@ public final class CloudSdkUtil {
   }
 
   /**
-   * Converts from a parent directory path to the Cloud SDK executable path
+   * Converts from a SDK home directory path to the Cloud SDK executable path
    *
    */
   public static String toExecutablePath(String sdkDirectoryPath) {
     if (sdkDirectoryPath != null) {
-      File executablePath = new File(sdkDirectoryPath, getSystemCommand());
+      File executablePath = new File(sdkDirectoryPath + File.separator + "bin", getSystemCommand());
       return executablePath.getAbsolutePath();
     }
 
@@ -106,12 +106,12 @@ public final class CloudSdkUtil {
   }
 
   /**
-   * Converts from a Cloud SDK executable path to its parent directory path
+   * Converts from a Cloud SDK executable path to its SDK home directory
    *
    */
-  public static String toParentDirectory(String sdkExecutablePath) {
+  public static String toSdkHomeDirectory(String sdkExecutablePath) {
     if (sdkExecutablePath != null) {
-      return new File(sdkExecutablePath).getParent();
+      return new File(sdkExecutablePath).getParentFile().getParent();
     }
 
     return null;

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurableTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/cloud/ManagedVmCloudConfigurableTest.java
@@ -43,11 +43,11 @@ public class ManagedVmCloudConfigurableTest extends PlatformTestCase {
   private JLabel warningMessage;
   private TextFieldWithBrowseButton cloudSdkDirectoryField;
 
-  private static final String CLOUD_SDK_EXECUTABLE_PATH = "/a/b/c/gcloud";
-  private static final String CLOUD_SDK_DIR_PATH = "/a/b/c";
+  private static final String CLOUD_SDK_EXECUTABLE_PATH = "/a/b/c/gcloud-sdk/bin/gcloud";
+  private static final String CLOUD_SDK_DIR_PATH = "/a/b/c/gcloud-sdk";
 
   private static final String MISSING_PROJECT_WARNING = "Please select a project.";
-  private static final String MISSING_SDK_DIR_WARNING = "Please select a Cloud SDK directory.";
+  private static final String MISSING_SDK_DIR_WARNING = "Please select a Cloud SDK home directory.";
 
   @Override
   public void setUp() throws Exception {
@@ -155,6 +155,8 @@ public class ManagedVmCloudConfigurableTest extends PlatformTestCase {
   private File createTempFile() throws IOException {
     TemporaryFolder tempFolder = new TemporaryFolder();
     tempFolder.create();
-    return tempFolder.newFile("gcloud");
+    File executable = new File(tempFolder.newFolder("bin"), "gcloud");
+    executable.createNewFile();
+    return executable;
   }
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/util/CloudSdkUtilTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/util/CloudSdkUtilTest.java
@@ -37,8 +37,8 @@ public class CloudSdkUtilTest extends BasePluginTestCase {
   @Mock
   private SystemEnvironmentProvider environmentProvider;
 
-  private static final String CLOUD_SDK_EXECUTABLE_PATH = "/a/b/c/gcloud";
-  private static final String CLOUD_SDK_DIR_PATH = "/a/b/c";
+  private static final String CLOUD_SDK_EXECUTABLE_PATH = "/a/b/c/gcloud-sdk/bin/gcloud";
+  private static final String CLOUD_SDK_DIR_PATH = "/a/b/c/gcloud-sdk";
 
   @Before
   public void setUp() {
@@ -70,6 +70,6 @@ public class CloudSdkUtilTest extends BasePluginTestCase {
     assertEquals(CLOUD_SDK_EXECUTABLE_PATH,
         CloudSdkUtil.toExecutablePath(CLOUD_SDK_DIR_PATH));
     assertEquals(CLOUD_SDK_DIR_PATH,
-        CloudSdkUtil.toParentDirectory(CLOUD_SDK_EXECUTABLE_PATH));
+        CloudSdkUtil.toSdkHomeDirectory(CLOUD_SDK_EXECUTABLE_PATH));
   }
 }


### PR DESCRIPTION
Addresses #535.

@etanshaul @patflynn PTAL

Prior to this change, when configuring the Google Cloud SDK for App Engine flexible environment, the user must select the bin subdirectory of the SDK installation path. This is counter to the expectation of the users that selecting the SDK home directory should work.