### PR TITLE
stop an app deployed to mvm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ subprojects {
             exclude group: 'org.hamcrest', module: 'hamcrest-core'
         }
         testCompile 'org.hamcrest:hamcrest-all:1.3'
+        compile 'joda-time:joda-time:2.9.2'
         compile 'com.google.code.findbugs:annotations:2.0.3'
     }
 

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -45,6 +45,8 @@ appengine.appyaml.location.label=app.yaml path\:
 appengine.dockerfile.location.browse.button=Browse for Your Dockerfile Location
 appengine.deployment.error.with.code=Deployment failed with exit code: {0}
 appengine.deployment.error.during.execution=Deployment failed due to an unexpected error during the deployment execution phase.
+appengine.stopapp.error.during.execution=Failed to stop application due to an unexpected error during the execution phase.
+appengine.stopapp.error.with.code=Stop application failed with exit code: {0}
 appengine.deployment.error.during.staging=Deployment failed due to an unexpected error while creating the staging directory for deployment.
 
 clonefromgcp.projectid=Cloud Project:

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineHelper.java
@@ -16,6 +16,8 @@
 
 package com.google.gct.idea.appengine.cloud;
 
+import com.intellij.openapi.project.Project;
+import com.intellij.remoteServer.runtime.deployment.DeploymentRuntime.UndeploymentTaskCallback;
 import com.intellij.remoteServer.runtime.deployment.ServerRuntimeInstance.DeploymentOperationCallback;
 import com.intellij.remoteServer.runtime.log.LoggingHandler;
 
@@ -66,8 +68,9 @@ public interface AppEngineHelper {
    * @param deploymentCallback a callback for handling successful completion of the operation
    * @return the runnable that will perform the deployment operation
    */
-  Runnable createCustomDeploymentOperation(
+  ManagedVmAction createCustomDeploymentAction(
       LoggingHandler loggingHandler,
+      Project project,
       File artifactToDeploy,
       File appYamlPath,
       File dockerfilePath,
@@ -82,8 +85,14 @@ public interface AppEngineHelper {
    * @param deploymentCallback a callback for handling successful completion of the operation
    * @return the runnable that will perform the deployment operation
    */
-  Runnable createAutoDeploymentOperation(
+  ManagedVmAction createAutoDeploymentAction(
       LoggingHandler loggingHandler,
+      Project project,
       File artifactToDeploy,
       DeploymentOperationCallback deploymentCallback);
+
+  ManagedVmAction createManagedVmStopAction(
+      LoggingHandler loggingHandler,
+      UndeploymentTaskCallback undeploymentTaskCallback
+  );
 }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineModuleListItem.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineModuleListItem.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.google.common.base.Objects;
+
+import org.jetbrains.annotations.NotNull;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+/**
+ * Represents the data of a single deployed application version
+ */
+public class AppEngineModuleListItem implements Comparable<AppEngineModuleListItem> {
+
+  private String moduleName;
+  private String version;
+  private DateTime versionDate;
+  private Long versionTime;
+  private Double trafficSplit;
+
+  private static final String VERSION_DATE_PATTERN = "yyyyMMdd";
+
+  public AppEngineModuleListItem(
+      String moduleName,
+      String version,
+      String versionDate,
+      String versionTime,
+      String trafficSplit) {
+    this.moduleName = moduleName;
+    this.version = version;
+
+    DateTimeFormatter fmt = DateTimeFormat.forPattern(VERSION_DATE_PATTERN);
+    this.versionDate = fmt.parseDateTime(versionDate);
+
+    this.versionTime = Long.parseLong(versionTime);
+    this.trafficSplit = Double.parseDouble(trafficSplit);
+  }
+
+  public Double getTrafficSplit() {
+    return trafficSplit;
+  }
+
+  public String getModuleName() {
+    return moduleName;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  /**
+   * Compares instances of this class using the following criteria evaluated in order:
+   * 1) Compare traffic split, if one is 0 then its lower, otherwise:
+   * 2) Compare dates, if equal then:
+   * 3) Compare time stamp
+   *
+   * @param that the object to compare to
+   * @return @see {@link Comparable#compareTo(Object)}
+   */
+  @Override
+  public int compareTo(@NotNull AppEngineModuleListItem that) {
+    int trafficSplitCompare;
+    if(this.trafficSplit == 0) {
+      trafficSplitCompare = -1;
+    } else if(that.trafficSplit == 0) {
+      trafficSplitCompare = 1;
+    } else {
+      trafficSplitCompare = 0;
+    }
+
+    int dateCompare = this.versionDate.compareTo(that.versionDate);
+
+    if (trafficSplitCompare != 0) {
+      return trafficSplitCompare;
+    } else if (dateCompare != 0) {
+        return dateCompare;
+    } else {
+      return this.versionTime.compareTo(that.versionTime);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AppEngineModuleListItem that = (AppEngineModuleListItem) o;
+
+    return Objects.equal(this.moduleName, that.moduleName)
+        && Objects.equal(this.version, that.version)
+        && Objects.equal(this.versionDate, that.versionDate)
+        && Objects.equal(this.versionTime, that.versionTime)
+        && Objects.equal(this.trafficSplit, that.trafficSplit);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        moduleName,
+        version,
+        versionDate,
+        versionTime,
+        trafficSplit
+    );
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineModuleListOutputParser.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineModuleListOutputParser.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.intellij.openapi.diagnostic.Logger;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Aggregates and parses individual module listing line items. Used to collect output from the
+ * command line and to query the results for the most recently deployed application (module+version
+ * combination).
+ *
+ */
+public class AppEngineModuleListOutputParser {
+  private static final Logger logger = Logger.getInstance(AppEngineModuleListOutputParser.class);
+
+  private List<AppEngineModuleListItem> moduleDeployTimes = new ArrayList<AppEngineModuleListItem>();
+
+  public void addLineItem(String lineItem) {
+    try {
+      moduleDeployTimes.add(parseLineItem(lineItem));
+    } catch (RuntimeException e) {
+      logger.warn(String.format("Unexpected module listing line item format: %s", lineItem), e);
+    }
+  }
+
+  @Nullable
+  public AppEngineModuleListItem getLatestDeployedModule() {
+    Collections.sort(moduleDeployTimes);
+    return moduleDeployTimes.isEmpty() ? null : moduleDeployTimes.get(moduleDeployTimes.size() - 1);
+  }
+
+  /**
+   * Given a line from the output of a module listing cli command, parse it into its individual
+   * components.
+   *
+   * Example line: "default  20160325t180009  1.0"
+   *
+   * @param line from module listing cli command
+   * @return @see {@link AppEngineModuleListItem}
+   * @throws RuntimeException
+   */
+  private AppEngineModuleListItem parseLineItem(String line) {
+    String[] items = line.split("\\s+");
+    String moduleName = items[0];
+    String version = items[1];
+    String trafficSplit = items[2];
+
+    String[] dateTimeComponents = version.split("t");
+    String versionDate = dateTimeComponents[0];
+    String versionTime = dateTimeComponents[1];
+
+    return new AppEngineModuleListItem(
+        moduleName,
+        version,
+        versionDate,
+        versionTime,
+        trafficSplit
+    );
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmAction.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmAction.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import com.google.gct.login.CredentialedUser;
+import com.google.gct.login.Services;
+import com.google.gdt.eclipse.login.common.GoogleLoginState;
+import com.google.gson.Gson;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.remoteServer.runtime.log.LoggingHandler;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+/**
+ * Base class for Managed VM runnable actions - e.g. deploy, stop. Provides implementations
+ * for executing CLI based commands.
+ */
+public abstract class ManagedVmAction implements Runnable {
+  private static final Logger logger = Logger.getInstance(ManagedVmAction.class);
+
+  private LoggingHandler loggingHandler;
+  private AppEngineHelper appEngineHelper;
+
+  public ManagedVmAction(
+      @NotNull LoggingHandler loggingHandler,
+      @NotNull AppEngineHelper appEngineHelper) {
+    this.loggingHandler = loggingHandler;
+    this.appEngineHelper = appEngineHelper;
+  }
+
+  protected LoggingHandler getLoggingHandler() {
+    return loggingHandler;
+  }
+
+  protected void executeProcess(
+      @NotNull GeneralCommandLine commandLine,
+      @NotNull ProcessListener listener) throws ExecutionException {
+    consoleLogLn("Executing: " + commandLine.getCommandLineString());
+
+    final Process process = commandLine.createProcess();
+    final ProcessHandler processHandler = new OSProcessHandler(process,
+        commandLine.getCommandLineString());
+    loggingHandler.attachToProcess(processHandler);
+    processHandler.addProcessListener(listener);
+    processHandler.startNotify();
+  }
+
+  private static final String CLIENT_ID_LABEL = "client_id";
+  private static final String CLIENT_SECRET_LABEL = "client_secret";
+  private static final String REFRESH_TOKEN_LABEL = "refresh_token";
+  private static final String GCLOUD_USER_TYPE_LABEL = "type";
+  private static final String GCLOUD_USER_TYPE = "authorized_user";
+
+  @VisibleForTesting
+  protected File createApplicationDefaultCredentials() {
+    CredentialedUser projectUser = Services.getLoginService().getAllUsers()
+        .get(appEngineHelper.getGoogleUsername());
+
+    GoogleLoginState googleLoginState;
+    if (projectUser != null) {
+      googleLoginState = projectUser
+          .getGoogleLoginState();
+    } else {
+      return null;
+    }
+    String clientId = googleLoginState.fetchOAuth2ClientId();
+    String clientSecret = googleLoginState.fetchOAuth2ClientSecret();
+    String refreshToken = googleLoginState.fetchOAuth2RefreshToken();
+    Map<String, String> credentialMap = ImmutableMap.of(
+        CLIENT_ID_LABEL, clientId,
+        CLIENT_SECRET_LABEL, clientSecret,
+        REFRESH_TOKEN_LABEL, refreshToken,
+        GCLOUD_USER_TYPE_LABEL, GCLOUD_USER_TYPE
+    );
+    String jsonCredential = new Gson().toJson(credentialMap);
+    File tempCredentialFilePath = null;
+    try {
+      tempCredentialFilePath = FileUtil
+          .createTempFile(
+              "tmp_google_application_default_credential",
+              "json",
+              true /* deleteOnExit */);
+      Files.write(jsonCredential, tempCredentialFilePath, Charset.forName("UTF-8"));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return tempCredentialFilePath;
+  }
+
+  protected void deleteCredentials(@NotNull File credentialsPath) {
+    if (credentialsPath.exists()) {
+      if (!credentialsPath.delete()) {
+        logger.warn("failed to delete credential file expected at "
+            + credentialsPath.getPath());
+      }
+    }
+  }
+
+  protected void consoleLogLn(String message, String... arguments) {
+    loggingHandler.print(String.format(message + "\n", (Object[]) arguments));
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudType.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmCloudType.java
@@ -244,20 +244,22 @@ public class ManagedVmCloudType extends ServerType<ManagedVmServerConfiguration>
           configuration.getCloudProjectName(),
           configuration.getGoogleUserName());
 
-      final Runnable doDeployment;
+      final ManagedVmAction doDeployment;
       ManagedVmDeploymentConfiguration deploymentConfig = task.getConfiguration();
       File deploymentSource = deploymentConfig.isUserSpecifiedArtifact() ?
           new File(deploymentConfig.getUserSpecifiedArtifactPath()) : task.getSource().getFile();
 
       if (deploymentConfig.getConfigType() == ConfigType.AUTO) {
-        doDeployment = appEngineHelper.createAutoDeploymentOperation(
+        doDeployment = appEngineHelper.createAutoDeploymentAction(
             logManager.getMainLoggingHandler(),
+            task.getProject(),
             deploymentSource,
             callback
         );
       } else {
-        doDeployment = appEngineHelper.createCustomDeploymentOperation(
+        doDeployment = appEngineHelper.createCustomDeploymentAction(
             logManager.getMainLoggingHandler(),
+            task.getProject(),
             deploymentSource,
             getFileFromFilePath(deploymentConfig.getAppYamlPath()),
             getFileFromFilePath(deploymentConfig.getDockerFilePath()),

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmStopAction.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/ManagedVmStopAction.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.gct.idea.appengine.cloud;
+
+import com.google.gct.idea.util.GctBundle;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.GeneralCommandLine.ParentEnvironmentType;
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.execution.process.ProcessOutputTypes;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Key;
+import com.intellij.remoteServer.runtime.deployment.DeploymentRuntime.UndeploymentTaskCallback;
+import com.intellij.remoteServer.runtime.log.LoggingHandler;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+
+/**
+ * Stops a ManagedVM based application running on GCP.
+ */
+public class ManagedVmStopAction extends ManagedVmAction {
+  private static final Logger logger = Logger.getInstance(ManagedVmStopAction.class);
+
+  private AppEngineHelper appEngineHelper;
+  private UndeploymentTaskCallback callback;
+
+  private boolean moduleListingStarted;
+
+  public ManagedVmStopAction(
+      @NotNull AppEngineHelper appEngineHelper,
+      @NotNull LoggingHandler loggingHandler,
+      @NotNull UndeploymentTaskCallback callback) {
+    super(loggingHandler, appEngineHelper);
+
+    this.appEngineHelper = appEngineHelper;
+    this.callback = callback;
+  }
+
+  @Override
+  public void run() {
+    final File appDefaultCredentialsPath = createApplicationDefaultCredentials();
+    if (appDefaultCredentialsPath == null) {
+      callback.errorOccurred(
+          GctBundle.message("appengine.deployment.credential.not.found",
+              appEngineHelper.getGoogleUsername()));
+      return;
+    }
+    GeneralCommandLine commandLine = new GeneralCommandLine(
+        appEngineHelper.getGcloudCommandPath().getAbsolutePath());
+
+    commandLine.addParameters("preview", "app", "modules", "list");
+
+    commandLine.addParameter("--project=" + appEngineHelper.getProjectId());
+    commandLine
+        .addParameter("--credential-file-override=" + appDefaultCredentialsPath.getAbsolutePath());
+    commandLine.withParentEnvironmentType(ParentEnvironmentType.CONSOLE);
+
+    try {
+      executeProcess(commandLine, new ListModulesProcessListener(appDefaultCredentialsPath));
+    } catch (ExecutionException e) {
+      logger.error(e);
+      callback.errorOccurred(GctBundle.message("appengine.stopapp.error.during.execution"));
+    }
+  }
+
+  private class ListModulesProcessListener implements ProcessListener {
+    private File defaultCredentialsPath;
+    private AppEngineModuleListOutputParser outputParser = new AppEngineModuleListOutputParser();
+
+    public ListModulesProcessListener(File defaultCredentialsPath) {
+      this.defaultCredentialsPath = defaultCredentialsPath;
+    }
+
+    @Override
+    public void startNotified(ProcessEvent event) {
+    }
+
+    @Override
+    public void processTerminated(ProcessEvent event) {
+      if (event.getExitCode() == 0) {
+        callback.succeeded();
+      } else {
+        stopApplicationFailure(event);
+        deleteCredentials(defaultCredentialsPath);
+      }
+    }
+
+    @Override
+    public void processWillTerminate(ProcessEvent event, boolean willBeDestroyed) {
+      AppEngineModuleListItem item = outputParser.getLatestDeployedModule();
+
+      if (item != null && item.getTrafficSplit() > 0) {
+        GeneralCommandLine commandLine = new GeneralCommandLine(
+            appEngineHelper.getGcloudCommandPath().getAbsolutePath());
+
+        commandLine.addParameters("preview", "app", "modules", "stop");
+        commandLine.addParameter(item.getModuleName());
+        commandLine.addParameters("--version", item.getVersion());
+
+        commandLine.addParameter("--project=" + appEngineHelper.getProjectId());
+        commandLine
+            .addParameter("--credential-file-override=" + defaultCredentialsPath.getAbsolutePath());
+        commandLine.withParentEnvironmentType(ParentEnvironmentType.CONSOLE);
+
+        try {
+          executeProcess(commandLine, new StopModuleProcessListener(defaultCredentialsPath));
+        } catch (ExecutionException e) {
+          logger.error(e);
+          callback.errorOccurred(GctBundle.message("appengine.stopapp.error.during.execution"));
+        }
+      } else {
+        logger.error("Failed to stop running application because no instances with traffic "
+            + "allocation were found.");
+        callback.errorOccurred(GctBundle.message("appengine.stopapp.error.during.execution"));
+      }
+    }
+
+    @Override
+    public void onTextAvailable(ProcessEvent event, Key outputType) {
+      if (outputType.equals(ProcessOutputTypes.STDOUT)) {
+        if (event.getText().toLowerCase().startsWith("module")) {
+          moduleListingStarted = true;
+        } else if (moduleListingStarted) {
+          outputParser.addLineItem(event.getText());
+        }
+      }
+    }
+  }
+
+  private class StopModuleProcessListener extends ProcessAdapter {
+    private File defaultCredentialsPath;
+
+    public StopModuleProcessListener(File defaultCredentialsPath) {
+      this.defaultCredentialsPath = defaultCredentialsPath;
+    }
+
+    @Override
+    public void processTerminated(ProcessEvent event) {
+      if (event.getExitCode() == 0) {
+        callback.succeeded();
+      } else {
+        stopApplicationFailure(event);
+      }
+
+      deleteCredentials(defaultCredentialsPath);
+    }
+  }
+
+  private void stopApplicationFailure(ProcessEvent event) {
+    logger.error("Application stop process exited with an error. Exit Code:" + event.getExitCode());
+    callback.errorOccurred(
+        GctBundle.message("appengine.stopapp.error.with.code", event.getExitCode()));
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/cloud/ManagedVmDeployActionTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/appengine/cloud/ManagedVmDeployActionTest.java
@@ -39,9 +39,9 @@ import java.io.FileReader;
 import java.util.Map;
 
 /**
- * Test case for {@link DoManagedVmDeployment}.
+ * Test case for {@link ManagedVmDeployAction}.
  */
-public class DoManagedVmDeploymentTest extends BasePluginTestCase {
+public class ManagedVmDeployActionTest extends BasePluginTestCase {
 
   @Mock private LoggingHandler loggingHandler;
   @Mock private File deploymentArtifactPath;
@@ -52,16 +52,17 @@ public class DoManagedVmDeploymentTest extends BasePluginTestCase {
   @Mock private GoogleLoginService googleLoginService;
   @Mock private CredentialedUser credentialedUser;
   @Mock private GoogleLoginState loginState;
-  DoManagedVmDeployment doManagedVmDeployment;
+  ManagedVmDeployAction managedVmDeployAction;
   File credentialFile;
 
   @Before
   public void initialize() {
     registerService(GoogleLoginService.class, googleLoginService);
     when(deploymentArtifactPath.getPath()).thenReturn("bla.jar");
-    doManagedVmDeployment = new DoManagedVmDeployment(
+    managedVmDeployAction = new ManagedVmDeployAction(
         appEngineHelper,
         loggingHandler,
+        getProject(),
         deploymentArtifactPath,
         appYamlPath,
         dockerFilePath,
@@ -80,7 +81,7 @@ public class DoManagedVmDeploymentTest extends BasePluginTestCase {
     when(loginState.fetchOAuth2ClientId()).thenReturn(clientId);
     when(loginState.fetchOAuth2ClientSecret()).thenReturn(clientSecret);
     when(loginState.fetchOAuth2RefreshToken()).thenReturn(refreshToken);
-    credentialFile = doManagedVmDeployment.createApplicationDefaultCredentials();
+    credentialFile = managedVmDeployAction.createApplicationDefaultCredentials();
     Map jsonMap = new Gson().fromJson(new FileReader(credentialFile), Map.class);
     assertEquals(clientId, jsonMap.get("client_id"));
     assertEquals(clientSecret, jsonMap.get("client_secret"));


### PR DESCRIPTION
Fixes #453 

May undergo more refactoring and needs some test coverage. Putting it out there so it can start being looked at.

Adds support to stop a MVM application that was just deployed. Hooks into the IJ undeploy UI. Works by querying gcloud for the list of deployed versions, selects the latest one, then executes a stop command.