### PR TITLE
Restore presentable name of "userSpecifiedSource"

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/CloudToolsPluginInitializationComponent.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/CloudToolsPluginInitializationComponent.java
@@ -16,12 +16,14 @@
 package com.google.gct.idea;
 
 import com.google.gct.idea.appengine.cloud.AppEngineCloudType;
+import com.google.gct.idea.appengine.cloud.AppEngineCloudType.UserSpecifiedPathDeploymentSourceType;
 import com.google.gct.idea.debugger.CloudDebugConfigType;
 
 import com.intellij.execution.configurations.ConfigurationType;
 import com.intellij.openapi.components.ApplicationComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.remoteServer.ServerType;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSourceType;
 import com.intellij.remoteServer.impl.configuration.deployment.DeployToServerConfigurationType;
 
 import org.jetbrains.annotations.NotNull;
@@ -56,6 +58,8 @@ public class CloudToolsPluginInitializationComponent implements ApplicationCompo
     if (pluginInfoService.shouldEnable(GctFeature.APPENGINE_FLEX)) {
       AppEngineCloudType appEngineCloudType = new AppEngineCloudType();
       pluginConfigurationService.registerExtension(ServerType.EP_NAME, appEngineCloudType);
+      pluginConfigurationService.registerExtension(DeploymentSourceType.EP_NAME,
+          new UserSpecifiedPathDeploymentSourceType());
       pluginConfigurationService.registerExtension(ConfigurationType.CONFIGURATION_TYPE_EP,
           new DeployToServerConfigurationType(appEngineCloudType));
     }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineDeploymentConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineDeploymentConfiguration.java
@@ -46,6 +46,8 @@ public class AppEngineDeploymentConfiguration extends
     }
   }
 
+  public static final String USER_SPECIFIED_ARTIFACT_PATH_ATTRIBUTE = "userSpecifiedArtifactPath";
+
   private String dockerFilePath;
   private String appYamlPath;
   private boolean userSpecifiedArtifact;
@@ -57,7 +59,7 @@ public class AppEngineDeploymentConfiguration extends
     return userSpecifiedArtifact;
   }
 
-  @Attribute("userSpecifiedArtifactPath")
+  @Attribute(USER_SPECIFIED_ARTIFACT_PATH_ATTRIBUTE)
   public String getUserSpecifiedArtifactPath() {
     return userSpecifiedArtifactPath;
   }


### PR DESCRIPTION
Fixes #526. This approach seems like an ideal solution. If you have existing Flex deployment configuration, you should delete it and create a new one for this to work.

There is one very strange compilation problem that I can't figure out why it's happening. Line 117 of 'ManagedVmDeployment.java'. All of a sudden, 'DeploymentConfigurator' requires a fully qualified name although other occurrences of the name are just fine. I just can't understand why. Tried JDKs with both 1.7, and 1.8, but to no avail.