### PR TITLE
App Engine deployment sets gcloud metrics tracking

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/DoManagedVmDeployment.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/DoManagedVmDeployment.java
@@ -122,6 +122,7 @@ class DoManagedVmDeployment implements Runnable {
     commandLine.withWorkDirectory(stagingDirectory);
     consoleLogLn(loggingHandler, "Working directory set to: " + stagingDirectory.getAbsolutePath());
     commandLine.withParentEnvironmentType(ParentEnvironmentType.CONSOLE);
+    commandLine.getEnvironment().put("CLOUDSDK_METRICS_ENVIRONMENT", "gcloud-intellij");
     Process process = null;
     try {
       consoleLogLn(loggingHandler, "Executing: " + commandLine.getCommandLineString());


### PR DESCRIPTION
#542

When we deploy to App Engine using gcloud CLI, we now set the CLOUDSDK_METRICS_ENVIRONMENT environment variable to 'gcloud-intellij' to track usage metrics correctly.