### PR TITLE
move deploy auth check to the connect callback

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -46,7 +46,7 @@ appengine.dockerfile.location.browse.button=Browse for Your Dockerfile Location
 appengine.deployment.error.with.code=Deployment failed with exit code: {0}\nPlease make sure that you are using the latest version of the Google Cloud SDK.\nRun ''gcloud components update'' to update the SDK. (See: https://cloud.google.com/sdk/gcloud/reference/components/update.)
 appengine.deployment.error.during.execution=Deployment failed due to an unexpected error during the deployment execution phase.
 appengine.deployment.error.during.staging=Deployment failed due to an unexpected error while creating the staging directory for deployment.
-appengine.deployment.error.not.logged.in=You must be logged in to deploy.
+appengine.deployment.error.not.logged.in=You must be logged in to perform this action.
 appengine.deployment.status.deploying=Deploying to App Engine
 appengine.deployment.error.invalid.cloudsdk=Invalid Cloud SDK directory path.
 

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineCloudType.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineCloudType.java
@@ -268,7 +268,9 @@ public class AppEngineCloudType extends ServerType<AppEngineServerConfiguration>
 
     @Override
     public void connect(@NotNull ConnectionCallback<AppEngineDeploymentConfiguration> callback) {
-      if (CloudSdkUtil.isCloudSdkExecutable(CloudSdkUtil.toExecutablePath(configuration.getCloudSdkHomePath()))) {
+      if (!Services.getLoginService().isLoggedIn()) {
+        callback.errorOccurred(GctBundle.message("appengine.deployment.error.not.logged.in"));
+      } else if (CloudSdkUtil.isCloudSdkExecutable(CloudSdkUtil.toExecutablePath(configuration.getCloudSdkHomePath()))) {
         callback.connected(new AppEngineRuntimeInstance(configuration));
       } else {
         callback.errorOccurred(GctBundle.message("appengine.deployment.error.invalid.cloudsdk"));


### PR DESCRIPTION
fixes #552 

There is no need to duplicate the auth checking in both connect() and deploy() since deploy calls connect. Now, if the user tries to "connect" without being logged in, then an error message will be shown (the only caveat being that it will say "You must be logged in to deploy.".

I think this is a little less confusing than having the connect button (which I couldn't yet figure out how to disable) appear to work but then the deploy fails due to missing auth ("connect" seems to suggest that auth is a prerequisite).