### PR TITLE
Set clientVersion on Cloud Debugger Debuggee calls

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/gct/idea/CloudToolsPluginInfoService.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/CloudToolsPluginInfoService.java
@@ -21,4 +21,12 @@ package com.google.gct.idea;
  * information service across google-cloud-tools-plugin and google-account-plugin
  */
 public interface CloudToolsPluginInfoService extends PluginInfoService {
+
+  /**
+   * Returns the fully qualified version of the plugin for specifying in Cloud Debugger API
+   * requests.
+   *
+   * @return "google.com/intellij/v{currentPluginVersion}"
+   */
+  String getClientVersionForCloudDebugger();
 }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/IdeaCloudToolsPluginInfoService.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/IdeaCloudToolsPluginInfoService.java
@@ -16,13 +16,21 @@
 
 package com.google.gct.idea;
 
+
 /**
  * The singleton instance of this class provides plugin metadata for the Google Cloud Tools plugin.
  */
 public class IdeaCloudToolsPluginInfoService extends BasePluginInfoService implements
     CloudToolsPluginInfoService {
 
+  private final static String CLIENT_VERSION_PREFIX = "google.com/intellij/v";
+
   protected IdeaCloudToolsPluginInfoService() {
     super("gcloud-intellij-cloud-tools-plugin", "com.google.gct.core");
+  }
+
+  @Override
+  public String getClientVersionForCloudDebugger() {
+    return CLIENT_VERSION_PREFIX + getPluginVersion();
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugGlobalPoller.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugGlobalPoller.java
@@ -22,6 +22,7 @@ import com.google.api.services.clouddebugger.v2.Clouddebugger.Debugger.Debuggees
 import com.google.api.services.clouddebugger.v2.Clouddebugger.Debugger.Debuggees.Breakpoints;
 import com.google.api.services.clouddebugger.v2.model.Breakpoint;
 import com.google.api.services.clouddebugger.v2.model.ListBreakpointsResponse;
+import com.google.gct.idea.CloudToolsPluginInfoService;
 import com.google.gct.idea.util.GctBundle;
 
 import com.intellij.notification.Notification;
@@ -29,6 +30,7 @@ import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.application.ApplicationAdapter;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.containers.ContainerUtil;
 
@@ -108,7 +110,9 @@ public class CloudDebugGlobalPoller {
         .setStripResults(Boolean.TRUE)
         .setWaitToken(state.getWaitToken());
 
-    ListBreakpointsResponse response = listRequest.execute();
+    ListBreakpointsResponse response = listRequest
+        .setClientVersion(ServiceManager.getService(CloudToolsPluginInfoService.class).getClientVersionForCloudDebugger())
+        .execute();
     List<Breakpoint> currentList = response.getBreakpoints();
     String responseWaitToken = response.getNextWaitToken();
     state.setWaitToken(responseWaitToken);

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/CloudDebugProcessStateController.java
@@ -19,8 +19,10 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.repackaged.com.google.common.base.Strings;
 import com.google.api.services.clouddebugger.v2.Clouddebugger.Debugger;
 import com.google.api.services.clouddebugger.v2.model.*;
+import com.google.gct.idea.CloudToolsPluginInfoService;
 import com.google.gct.idea.util.GctBundle;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.util.containers.ContainerUtil;
@@ -91,7 +93,9 @@ public class CloudDebugProcessStateController {
       @Override
       public void run() {
         try {
-          client.debuggees().breakpoints().delete(debuggeeId, breakpointId).execute();
+          client.debuggees().breakpoints().delete(debuggeeId, breakpointId)
+              .setClientVersion(ServiceManager.getService(CloudToolsPluginInfoService.class).getClientVersionForCloudDebugger())
+              .execute();
         } catch (IOException ex) {
           LOG.warn("exception deleting breakpoint " + breakpointId, ex);
         }
@@ -173,7 +177,9 @@ public class CloudDebugProcessStateController {
         // back on ui
         GetBreakpointResponse response;
         try {
-          response = client.debuggees().breakpoints().get(state.getDebuggeeId(), id).execute();
+          response = client.debuggees().breakpoints().get(state.getDebuggeeId(), id)
+              .setClientVersion(ServiceManager.getService(CloudToolsPluginInfoService.class).getClientVersionForCloudDebugger())
+              .execute();
           Breakpoint result = response.getBreakpoint();
           if (result != null) {
             fullFinalBreakpoints.put(id, result);
@@ -229,7 +235,9 @@ public class CloudDebugProcessStateController {
           }
 
           SetBreakpointResponse addResponse =
-              client.debuggees().breakpoints().set(debuggeeId, serverBreakpoint).execute();
+              client.debuggees().breakpoints().set(debuggeeId, serverBreakpoint)
+                  .setClientVersion(ServiceManager.getService(CloudToolsPluginInfoService.class).getClientVersionForCloudDebugger())
+                  .execute();
 
           if (addResponse != null && addResponse.getBreakpoint() != null) {
             Breakpoint result = addResponse.getBreakpoint();
@@ -365,7 +373,9 @@ public class CloudDebugProcessStateController {
           client.debuggees().breakpoints().list(state.getDebuggeeId())
               .setIncludeInactive(Boolean.TRUE).setActionValue("CAPTURE")
               .setStripResults(Boolean.TRUE)
-              .setWaitToken(CloudDebugConfigType.useWaitToken() ? tokenToSend : null).execute();
+              .setWaitToken(CloudDebugConfigType.useWaitToken() ? tokenToSend : null)
+              .setClientVersion(ServiceManager.getService(CloudToolsPluginInfoService.class).getClientVersionForCloudDebugger())
+              .execute();
 
       //We are running on a background thread and the cancel can happen any time triggered
       //on the ui thread from the user.  We want to short circuit immediately and not change

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ProjectRepositoryValidator.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ProjectRepositoryValidator.java
@@ -23,6 +23,7 @@ import com.google.api.services.clouddebugger.v2.model.GerritSourceContext;
 import com.google.api.services.clouddebugger.v2.model.GitSourceContext;
 import com.google.api.services.clouddebugger.v2.model.ListDebuggeesResponse;
 import com.google.api.services.clouddebugger.v2.model.SourceContext;
+import com.google.gct.idea.CloudToolsPluginInfoService;
 import com.google.gct.idea.util.GctBundle;
 import com.intellij.dvcs.DvcsUtil;
 import com.intellij.execution.configurations.GeneralCommandLine;
@@ -115,7 +116,9 @@ public class ProjectRepositoryValidator {
         !com.google.common.base.Strings.isNullOrEmpty(processState.getProjectNumber())) {
       ListDebuggeesResponse debuggees;
       try {
-        debuggees = getCloudDebuggerClient().debuggees().list().setProject(processState.getProjectNumber()).execute();
+        debuggees = getCloudDebuggerClient().debuggees().list().setProject(processState.getProjectNumber())
+            .setClientVersion(ServiceManager.getService(CloudToolsPluginInfoService.class).getClientVersionForCloudDebugger())
+            .execute();
         for (Debuggee debuggee : debuggees.getDebuggees()) {
           if (processState.getDebuggeeId() != null && processState.getDebuggeeId().equals(debuggee.getId())) {
             // implicit assumption this doesn't happen more than once

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/ProjectDebuggeeBinding.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/debugger/ui/ProjectDebuggeeBinding.java
@@ -20,6 +20,7 @@ import com.google.api.services.clouddebugger.v2.Clouddebugger.Debugger;
 import com.google.api.services.clouddebugger.v2.model.Debuggee;
 import com.google.api.services.clouddebugger.v2.model.ListDebuggeesResponse;
 import com.google.common.base.Strings;
+import com.google.gct.idea.CloudToolsPluginInfoService;
 import com.google.gct.idea.debugger.CloudDebugProcessState;
 import com.google.gct.idea.debugger.CloudDebuggerClient;
 import com.google.gct.idea.elysium.ProjectSelector;
@@ -27,6 +28,7 @@ import com.google.gct.idea.util.GctBundle;
 import com.google.gct.login.CredentialedUser;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.DocumentAdapter;
@@ -151,6 +153,7 @@ class ProjectDebuggeeBinding {
           if (projectSelector.getProjectNumber() != null && getCloudDebuggerClient() != null) {
             final ListDebuggeesResponse debuggees = getCloudDebuggerClient().debuggees().list()
                 .setProject(projectSelector.getProjectNumber().toString())
+                .setClientVersion(ServiceManager.getService(CloudToolsPluginInfoService.class).getClientVersionForCloudDebugger())
                 .execute();
             isCdbQueried = true;
 

--- a/google-cloud-tools-plugin/testSrc/com/google/gct/idea/debugger/CloudDebugProcessStateTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/gct/idea/debugger/CloudDebugProcessStateTest.java
@@ -25,12 +25,14 @@ import com.google.api.services.clouddebugger.v2.model.FormatMessage;
 import com.google.api.services.clouddebugger.v2.model.ListBreakpointsResponse;
 import com.google.api.services.clouddebugger.v2.model.SourceLocation;
 import com.google.api.services.clouddebugger.v2.model.StatusMessage;
+import com.google.gct.idea.CloudToolsPluginInfoService;
 import com.google.gct.idea.testing.TestUtils;
 import com.google.gct.login.CredentialedUser;
 import com.google.gct.login.GoogleLoginService;
 import com.google.gdt.eclipse.login.common.GoogleLoginState;
 
 import com.intellij.mock.MockProjectEx;
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.psi.PsiManager;
 import com.intellij.testFramework.IdeaTestCase;
 import com.intellij.testFramework.UsefulTestCase;
@@ -236,6 +238,8 @@ public class CloudDebugProcessStateTest extends UsefulTestCase {
     when(list.setActionValue("CAPTURE")).thenReturn(list);
     when(list.setStripResults(Boolean.TRUE)).thenReturn(list);
     when(list.setWaitToken(null)).thenReturn(list);
+    when(list.setClientVersion(ServiceManager.getService(CloudToolsPluginInfoService.class).getClientVersionForCloudDebugger()))
+        .thenReturn(list);
     when(list.execute()).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {


### PR DESCRIPTION
Fixes #558.

This change sets client version string to be "google.com/intellij/v{currentPluginVersion}".