### PR TITLE
Show IO errors in an error dialog

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -38,7 +38,7 @@ appengine.flex.config.destination.overwrite.title=Confirm Overwrite
 appengine.flex.config.destination.not.directory=The path is not a directory. Please choose a directory.
 appengine.flex.config.destination.not.directory.title=Error
 appengine.flex.config.destination.chooser.directory.missing=Please select a directory.
-appengine.flex.config.generation.io.error=There was an error generating the {0}. Error details:\n\n
+appengine.flex.config.generation.io.error=There was an error generating the {0}.\n\nError reason\:
 appengine.config.project.panel.title=Project: {0}
 appengine.flex.config.user.specified.artifact.title=Select a JAR or WAR file
 appengine.flex.config.user.specified.artifact.error=Browse to a JAR or WAR file.
@@ -47,7 +47,7 @@ appengine.config.deployment.source.error=Select a valid deployment source.
 appengine.flex.deployment.cost.warning=<html><font face="sans" size="-1"><i>There is no free quota for App Engine Flexible Environment deployments. Please visit <a href\="https://cloud.google.com/appengine/pricing">GCP Pricing</a> for pricing information.</i></font></html>
 appengine.flex.user.specified.deploymentsource.name=Filesystem JAR or WAR file
 appengine.flex.user.specified.deploymentsource.name.with.filename=Filesystem JAR or WAR file - {0}
-appengine.deployment.credential.not.found=We were unable to find a credential for your cloud project's user. Are you sure {0} is logged in?"
+appengine.deployment.credential.not.found=We were unable to find a credential for your cloud project's user. Are you sure {0} is logged in?
 appengine.deployment.error.creating.staging.directory=There was an unexpected error creating the staging directory
 appengine.generate.config.button=Generate...
 appengine.appyaml.location.label=app.yaml path\:

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -38,6 +38,7 @@ appengine.flex.config.destination.overwrite.title=Confirm Overwrite
 appengine.flex.config.destination.not.directory=The path is not a directory. Please choose a directory.
 appengine.flex.config.destination.not.directory.title=Error
 appengine.flex.config.destination.chooser.directory.missing=Please select a directory.
+appengine.flex.config.generation.io.error=There was an error generating the {0}. Error details:\n\n
 appengine.config.project.panel.title=Project: {0}
 appengine.flex.config.user.specified.artifact.title=Select a JAR or WAR file
 appengine.flex.config.user.specified.artifact.error=Browse to a JAR or WAR file.

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -27,6 +27,7 @@ import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.MessageType;
+import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.ui.popup.Balloon.Position;
@@ -341,7 +342,8 @@ public class AppEngineDeploymentRunConfigurationEditor extends
           FileUtil.copy(sourceFileProvider.get(), destinationFilePath);
           LocalFileSystem.getInstance().refreshAndFindFileByIoFile(destinationFilePath);
         } catch (IOException e) {
-          throw new RuntimeException(e);
+          Messages.showErrorDialog(project, e.getLocalizedMessage(), "Error");
+          return;
         }
         filePicker.setText(destinationFilePath.getPath());
       }

--- a/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/gct/idea/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -342,7 +342,9 @@ public class AppEngineDeploymentRunConfigurationEditor extends
           FileUtil.copy(sourceFileProvider.get(), destinationFilePath);
           LocalFileSystem.getInstance().refreshAndFindFileByIoFile(destinationFilePath);
         } catch (IOException e) {
-          Messages.showErrorDialog(project, e.getLocalizedMessage(), "Error");
+          String message = GctBundle.message(
+              "appengine.flex.config.generation.io.error", destinationFilePath.getName());
+          Messages.showErrorDialog(project, message + e.getLocalizedMessage(), "Error");
           return;
         }
         filePicker.setText(destinationFilePath.getPath());


### PR DESCRIPTION
Fixes #574.

Since it is IOExceptions, I think it is okay to display any of them in a dialog.

![ioerror_dialog](https://cloud.githubusercontent.com/assets/10523105/14259684/f1c0de62-fa75-11e5-9ac5-f05fd6f1904f.png)
