### PR TITLE
Explicit setting of JTextPane background color

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudConfigurable.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudConfigurable.java
@@ -17,12 +17,12 @@
 package com.google.cloud.tools.intellij.appengine.cloud;
 
 import com.google.cloud.tools.intellij.appengine.util.CloudSdkUtil;
-import com.google.cloud.tools.intellij.util.SystemEnvironmentProvider;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.cloud.tools.intellij.elysium.ProjectSelector;
+import com.google.cloud.tools.intellij.login.CredentialedUser;
 import com.google.cloud.tools.intellij.ui.BrowserOpeningHyperLinkListener;
 import com.google.cloud.tools.intellij.util.GctBundle;
-import com.google.cloud.tools.intellij.login.CredentialedUser;
+import com.google.cloud.tools.intellij.util.SystemEnvironmentProvider;
+import com.google.common.annotations.VisibleForTesting;
 
 import com.intellij.execution.configurations.RuntimeConfigurationError;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
@@ -71,6 +71,8 @@ public class AppEngineCloudConfigurable extends RemoteServerConfigurable impleme
             MORE_INFO_URI_OPEN_TAG,
             MORE_INFO_URI_CLOSE_TAG));
     appEngineFlexMoreInfoLabel.addHyperlinkListener(new BrowserOpeningHyperLinkListener());
+    appEngineFlexMoreInfoLabel.setBackground(mainPanel.getBackground());
+
     environmentProvider = SystemEnvironmentProvider.getInstance();
 
     warningMessage.setVisible(false);

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -16,13 +16,13 @@
 
 package com.google.cloud.tools.intellij.appengine.cloud;
 
-import com.google.common.base.Supplier;
 import com.google.cloud.tools.intellij.appengine.cloud.AppEngineCloudType.AppEngineDeploymentConfigurator.UserSpecifiedPathDeploymentSource;
 import com.google.cloud.tools.intellij.appengine.cloud.AppEngineDeploymentConfiguration.ConfigType;
-import com.google.cloud.tools.intellij.ui.PlaceholderTextField;
-import com.google.cloud.tools.intellij.ui.BrowserOpeningHyperLinkListener;
 import com.google.cloud.tools.intellij.appengine.cloud.FileConfirmationDialog.DialogType;
+import com.google.cloud.tools.intellij.ui.BrowserOpeningHyperLinkListener;
+import com.google.cloud.tools.intellij.ui.PlaceholderTextField;
 import com.google.cloud.tools.intellij.util.GctBundle;
+import com.google.common.base.Supplier;
 
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.ConfigurationException;
@@ -125,6 +125,7 @@ public class AppEngineDeploymentRunConfigurationEditor extends
             COST_WARNING_HREF_CLOSE_TAG,
             COST_WARNING_CLOSE_TAG));
     appEngineCostWarningLabel.addHyperlinkListener(new BrowserOpeningHyperLinkListener());
+    appEngineCostWarningLabel.setBackground(editorPanel.getBackground());
 
     configTypeComboBox.setModel(new DefaultComboBoxModel(ConfigType.values()));
     configTypeComboBox.setSelectedItem(ConfigType.AUTO);


### PR DESCRIPTION
fixes #594 

OSX:

<img width="562" alt="screen shot 2016-04-06 at 5 28 00 pm" src="https://cloud.githubusercontent.com/assets/1735744/14333526/202976bc-fc1d-11e5-95ad-87db28128d0f.png">
<img width="766" alt="screen shot 2016-04-06 at 5 27 50 pm" src="https://cloud.githubusercontent.com/assets/1735744/14333528/2245e28c-fc1d-11e5-8118-5000019cf508.png">


Pending test in Linux.