### PR TITLE
Listen for project closing event and close all active server connections

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudType.java
@@ -32,6 +32,8 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.ProjectManagerAdapter;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.packaging.artifacts.Artifact;
 import com.intellij.packaging.artifacts.ArtifactManager;
@@ -45,6 +47,8 @@ import com.intellij.remoteServer.configuration.deployment.JavaDeploymentSourceUt
 import com.intellij.remoteServer.configuration.deployment.ModuleDeploymentSource;
 import com.intellij.remoteServer.impl.configuration.deployment.DeployToServerRunConfiguration;
 import com.intellij.remoteServer.impl.configuration.deployment.ModuleDeploymentSourceImpl;
+import com.intellij.remoteServer.runtime.ServerConnection;
+import com.intellij.remoteServer.runtime.ServerConnectionManager;
 import com.intellij.remoteServer.runtime.ServerConnector;
 import com.intellij.remoteServer.runtime.ServerTaskExecutor;
 import com.intellij.remoteServer.runtime.deployment.DeploymentLogManager;
@@ -71,6 +75,20 @@ public class AppEngineCloudType extends ServerType<AppEngineServerConfiguration>
 
   public AppEngineCloudType() {
     super("gcp-app-engine"); // "google-app-engine" is used by the native IJ app engine support.
+
+    // listen for project closing event and close all active server connections
+    ProjectManager.getInstance().addProjectManagerListener(new ProjectManagerAdapter() {
+      @Override
+      public void projectClosing(Project project) {
+        super.projectClosing(project);
+        for (ServerConnection connection : ServerConnectionManager.getInstance().getConnections()) {
+          if (connection.getServer().getType() instanceof  AppEngineCloudType) {
+            connection.disconnect();
+          }
+        }
+      }
+    });
+
   }
 
   @NotNull

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudType.java
@@ -77,17 +77,21 @@ public class AppEngineCloudType extends ServerType<AppEngineServerConfiguration>
     super("gcp-app-engine"); // "google-app-engine" is used by the native IJ app engine support.
 
     // listen for project closing event and close all active server connections
-    ProjectManager.getInstance().addProjectManagerListener(new ProjectManagerAdapter() {
-      @Override
-      public void projectClosing(Project project) {
-        super.projectClosing(project);
-        for (ServerConnection connection : ServerConnectionManager.getInstance().getConnections()) {
-          if (connection.getServer().getType() instanceof  AppEngineCloudType) {
-            connection.disconnect();
+    ProjectManager projectManager = ProjectManager.getInstance();
+    if (projectManager != null) {
+      projectManager.addProjectManagerListener(new ProjectManagerAdapter() {
+        @Override
+        public void projectClosing(Project project) {
+          super.projectClosing(project);
+          for (ServerConnection connection : ServerConnectionManager.getInstance()
+              .getConnections()) {
+            if (connection.getServer().getType() instanceof AppEngineCloudType) {
+              connection.disconnect();
+            }
           }
         }
-      }
-    });
+      });
+    }
 
   }
 


### PR DESCRIPTION
Fixes #577.

The IDE cannot properly restore active server connections after a project is reopened. Therefore, it's necessary to disconnect all active server connections when the project is closing.