### PR TITLE
Disconnect on server instance stops deployment [See #630]

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineAction.java
@@ -68,15 +68,6 @@ public abstract class AppEngineAction implements Runnable {
     this.callback = callback;
   }
 
-  /**
-   * Returns the commandline process handler used to execute the action
-   *
-   * @return the process handler, or null, if the action is not executing
-   */
-  public ProcessHandler getProcessHandler() {
-    return processHandler;
-  }
-
   protected LoggingHandler getLoggingHandler() {
     return loggingHandler;
   }
@@ -124,6 +115,14 @@ public abstract class AppEngineAction implements Runnable {
     });
 
     processHandler.startNotify();
+  }
+
+  protected void cancel() {
+    // kill any executing process for the action
+    if (processHandler != null) {
+      processHandler.destroyProcess();
+      processHandler = null;
+    }
   }
 
   private static final String CLIENT_ID_LABEL = "client_id";

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineAction.java
@@ -81,7 +81,7 @@ public abstract class AppEngineAction implements Runnable {
     return loggingHandler;
   }
 
-  protected synchronized void executeProcess(
+  protected void executeProcess(
       @NotNull GeneralCommandLine commandLine,
       @NotNull ProcessListener listener) throws ExecutionException {
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineAction.java
@@ -31,7 +31,6 @@ import com.intellij.execution.configurations.GeneralCommandLine.ParentEnvironmen
 import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
-import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.io.FileUtil;

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineAction.java
@@ -57,7 +57,7 @@ public abstract class AppEngineAction implements Runnable {
   private AppEngineHelper appEngineHelper;
   private File credentialsPath;
   private RemoteOperationCallback callback;
-  private ProcessHandler processHandler;
+  private OSProcessHandler processHandler;
 
   public AppEngineAction(
       @NotNull LoggingHandler loggingHandler,
@@ -76,11 +76,8 @@ public abstract class AppEngineAction implements Runnable {
       @NotNull GeneralCommandLine commandLine,
       @NotNull ProcessListener listener) throws ExecutionException {
 
-    // kill action process if one is already executing
-    if (processHandler != null) {
-      processHandler.destroyProcess();
-      processHandler = null;
-    }
+    // kill action if it's already executing
+    cancel();
 
     credentialsPath = createApplicationDefaultCredentials();
     if (credentialsPath == null) {
@@ -120,7 +117,7 @@ public abstract class AppEngineAction implements Runnable {
   protected void cancel() {
     // kill any executing process for the action
     if (processHandler != null) {
-      processHandler.destroyProcess();
+      processHandler.getProcess().destroy();
       processHandler = null;
     }
   }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudType.java
@@ -387,10 +387,10 @@ public class AppEngineCloudType extends ServerType<AppEngineServerConfiguration>
     @Override
     public synchronized void disconnect() {
       // kill any executing process for the current action
-      if (currentAction != null && currentAction.getProcessHandler() != null) {
-        currentAction.getProcessHandler().destroyProcess();
+      if (currentAction != null) {
+        currentAction.cancel();
+        currentAction = null;
       }
-      currentAction = null;
     }
 
     @NotNull

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployAction.java
@@ -171,6 +171,9 @@ class AppEngineDeployAction extends AppEngineAction {
       try {
         if (event.getExitCode() == 0) {
           callback.succeeded(new DeploymentRuntimeImpl(deploymentOutput.toString(), version));
+        } else if (event.getExitCode() == 137) {
+          // process killed (message should never be seen by user)
+          callback.errorOccurred("Deployment process was killed.");
         } else {
           logger.error("Deployment process exited with an error. Exit Code:" + event.getExitCode());
           callback.errorOccurred(

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployAction.java
@@ -171,9 +171,9 @@ class AppEngineDeployAction extends AppEngineAction {
       try {
         if (event.getExitCode() == 0) {
           callback.succeeded(new DeploymentRuntimeImpl(deploymentOutput.toString(), version));
-        } else if (event.getExitCode() == 143) {
-          // process killed (message should never be seen by user)
-          callback.errorOccurred("Deployment process was killed.");
+        } else if (cancelled) {
+          // process cancelled (message should never be seen by user)
+          callback.errorOccurred("Deployment process was cancelled.");
         } else {
           logger.error("Deployment process exited with an error. Exit Code:" + event.getExitCode());
           callback.errorOccurred(

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeployAction.java
@@ -171,7 +171,7 @@ class AppEngineDeployAction extends AppEngineAction {
       try {
         if (event.getExitCode() == 0) {
           callback.succeeded(new DeploymentRuntimeImpl(deploymentOutput.toString(), version));
-        } else if (event.getExitCode() == 137) {
+        } else if (event.getExitCode() == 143) {
           // process killed (message should never be seen by user)
           callback.errorOccurred("Deployment process was killed.");
         } else {


### PR DESCRIPTION
Fixes #588 and #581.

The process that executes the deployment is tracked and killed when a disconnect is invoked on the App Engine Server Instance.

The disconnect is also called when:

1. The project is closing (Fixes #588)
2. A new deployment is started while another one is in progress
3. The stop action is invoked for the App Engine server in the UI. (Fixes #581)