### PR TITLE
Add tools menu link to flex deployment config

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -17,7 +17,7 @@
 select.project.signin=Sign in with your Google account to list your Google Developers Console projects.
 
 cloud.project.label=Project\:
-
+appengine.flex.tools.menu.item.label=Deploy to App Engine flexible environment...
 appengine.cloudsdk.location.label=Cloud SDK directory\:
 appengine.cloudsdk.location.browse.window.title=Browse to Cloud SDK directory
 appengine.cloudsdk.location.missing.message=Please select a Cloud SDK home directory.

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/CloudToolsPluginInitializationComponent.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/CloudToolsPluginInitializationComponent.java
@@ -17,9 +17,14 @@ package com.google.cloud.tools.intellij;
 
 import com.google.cloud.tools.intellij.appengine.cloud.AppEngineCloudType;
 import com.google.cloud.tools.intellij.appengine.cloud.AppEngineCloudType.UserSpecifiedPathDeploymentSourceType;
+import com.google.cloud.tools.intellij.appengine.cloud.AppEngineToolsMenuAction;
 import com.google.cloud.tools.intellij.debugger.CloudDebugConfigType;
 
 import com.intellij.execution.configurations.ConfigurationType;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.Constraints;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.components.ApplicationComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.remoteServer.ServerType;
@@ -62,6 +67,13 @@ public class CloudToolsPluginInitializationComponent implements ApplicationCompo
           new UserSpecifiedPathDeploymentSourceType());
       pluginConfigurationService.registerExtension(ConfigurationType.CONFIGURATION_TYPE_EP,
           new DeployToServerConfigurationType(appEngineCloudType));
+
+      ActionManager actionManager = ActionManager.getInstance();
+      AnAction toolsMenuAction = new AppEngineToolsMenuAction();
+      actionManager.registerAction(AppEngineToolsMenuAction.ID , toolsMenuAction);
+      DefaultActionGroup toolsMenu =
+          (DefaultActionGroup) actionManager.getAction(AppEngineToolsMenuAction.GROUP_ID);
+      toolsMenu.add(toolsMenuAction, Constraints.LAST);
     }
     if (pluginInfoService.shouldEnableErrorFeedbackReporting()) {
       pluginConfigurationService

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineToolsMenuAction.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineToolsMenuAction.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.cloud;
+
+import com.google.cloud.tools.intellij.ui.GoogleCloudToolsIcons;
+import com.google.cloud.tools.intellij.util.GctBundle;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
+import com.intellij.remoteServer.ServerType;
+import com.intellij.remoteServer.configuration.RemoteServer;
+import com.intellij.remoteServer.configuration.RemoteServersManager;
+import com.intellij.remoteServer.configuration.deployment.DeploymentConfigurationManager;
+import com.intellij.util.containers.ContainerUtil;
+
+import java.util.List;
+
+/**
+ * Creates a shortcut to App Engine flex cloud configuration in the tools menu
+ */
+public class AppEngineToolsMenuAction extends AnAction {
+  public static final String ID = "CloudToolsMenuItem";
+  public static final String GROUP_ID = "ToolsMenu";
+
+  public AppEngineToolsMenuAction() {
+    super(GctBundle.message("appengine.flex.tools.menu.item.label"),
+        GctBundle.message("appengine.flex.tools.menu.item.label"),
+        GoogleCloudToolsIcons.APP_ENGINE);
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    Project project = e.getProject();
+
+    if (project != null) {
+      AppEngineCloudType serverType = ServerType.EP_NAME.findExtension(AppEngineCloudType.class);
+      List<RemoteServer<AppEngineServerConfiguration>> servers =
+          RemoteServersManager.getInstance().getServers(serverType);
+
+      DeploymentConfigurationManager.getInstance(project).
+          createAndRunConfiguration(serverType, ContainerUtil.getFirstItem(servers));
+    }
+  }
+}

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/CloudToolsPluginInitializationComponentTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/CloudToolsPluginInitializationComponentTest.java
@@ -26,6 +26,8 @@ import com.google.cloud.tools.intellij.appengine.cloud.AppEngineCloudType;
 import com.google.cloud.tools.intellij.debugger.CloudDebugConfigType;
 import com.google.cloud.tools.intellij.testing.BasePluginTestCase;
 
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.extensions.ExtensionPointName;
 
 import org.junit.Before;
@@ -46,12 +48,15 @@ public class CloudToolsPluginInitializationComponentTest extends BasePluginTestC
   CloudToolsPluginInfoService pluginInfoService;
   @Mock
   CloudToolsPluginConfigurationService pluginConfigurationService;
+  @Mock
+  ActionManager actionManager;
   CloudToolsPluginInitializationComponent testComponent;
 
   @Before
   public void registerMockServices() {
     registerService(CloudToolsPluginInfoService.class, pluginInfoService);
     registerService(CloudToolsPluginConfigurationService.class, pluginConfigurationService);
+    registerService(ActionManager.class, actionManager);
     testComponent = new CloudToolsPluginInitializationComponent();
   }
 
@@ -76,6 +81,7 @@ public class CloudToolsPluginInitializationComponentTest extends BasePluginTestC
   @Test
   public void testInitComponent_managedVmIsEnabled() {
     when(pluginInfoService.shouldEnable(GctFeature.APPENGINE_FLEX)).thenReturn(true);
+    when(actionManager.getAction(anyString())).thenReturn(new DefaultActionGroup());
     testComponent.initComponent();
     verify(pluginConfigurationService).registerExtension(isA(ExtensionPointName.class),
         isA(AppEngineCloudType.class));


### PR DESCRIPTION
fixes #612 

Using this as a starting point for discussing what features we want to support.

Adds a new menu item to the tools menu which currently links to the settings cloud configuration page:

<img width="535" alt="screen shot 2016-04-13 at 2 38 52 pm" src="https://cloud.githubusercontent.com/assets/1735744/14505052/7b7247c0-0185-11e6-84d2-165c0170d340.png">

Clicking the link takes the user to the Cloud Configuration where a new flex env configuration can be made.