### PR TITLE
DBG_ENBALE in app.yaml to enable Cloud Debugger

### DIFF
--- a/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/app.yaml
+++ b/google-cloud-tools-plugin/resources/generation/src/appengine/mvm/app.yaml
@@ -1,2 +1,4 @@
 runtime: custom
 vm: true
+env_variables:
+  'DBG_ENABLE': 'true'


### PR DESCRIPTION
Fixes #626.

The decision for now is to do this as a workaround for our story. That is, only Java apps from our IDE plugin will enable Cloud Debugger for flex runtimes (non-compat jetty9 and openjdk-8).

The App Engine team and the Cloud Debugger team may eventually agree on getting rid of this env variable for Java and other languages, but that really seems a long way down.