### PR TITLE
Pre-fill path fields if project has usual files

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -101,6 +101,8 @@ public class AppEngineDeploymentRunConfigurationEditor extends
   private static final String COST_WARNING_HREF_OPEN_TAG =
       "<a href='https://cloud.google.com/appengine/pricing'>";
   private static final String COST_WARNING_HREF_CLOSE_TAG = "</a>";
+  public static final String DEFAULT_APP_YAML_DIR = "/src/main/appengine";
+  public static final String DEFAULT_DOCKERFILE_DIR = "/src/main/docker";
 
   public AppEngineDeploymentRunConfigurationEditor(
       final Project project,
@@ -136,6 +138,25 @@ public class AppEngineDeploymentRunConfigurationEditor extends
       public void actionPerformed(ActionEvent e) {
         if (getConfigType() == ConfigType.CUSTOM) {
           appEngineConfigFilesPanel.setVisible(true);
+
+          // For user convenience, pre-fill the path fields for app.yaml and Dockerfile
+          // if they already exist in their usual directories in the current project.
+          if (project != null && project.getBasePath() != null) {
+            if (StringUtil.isEmpty(appYamlPathField.getText())) {
+              String defaultAppYamlPath =
+                  project.getBasePath() + DEFAULT_APP_YAML_DIR + "/app.yaml";
+              if (new File(defaultAppYamlPath).exists()) {
+                appYamlPathField.setText(defaultAppYamlPath);
+              }
+            }
+            if (StringUtil.isEmpty(dockerFilePathField.getText())) {
+              String defaultDockerfilePath =
+                  project.getBasePath() + DEFAULT_DOCKERFILE_DIR + "/Dockerfile";
+              if (new File(defaultDockerfilePath).exists()) {
+                dockerFilePathField.setText(defaultDockerfilePath);
+              }
+            }
+          }
         } else {
           appEngineConfigFilesPanel.setVisible(false);
         }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/SelectConfigDestinationFolderDialog.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/SelectConfigDestinationFolderDialog.java
@@ -59,9 +59,11 @@ public class SelectConfigDestinationFolderDialog extends DialogWrapper {
     // Present a canonical target folder as default in the path field.
     if (project != null && project.getBasePath() != null) {
       if (fileType == ConfigFileType.APP_YAML) {
-        destinationFolderChooser.setText(project.getBasePath() + "/src/main/appengine");
+        destinationFolderChooser.setText(project.getBasePath() +
+            AppEngineDeploymentRunConfigurationEditor.DEFAULT_APP_YAML_DIR);
       } else if (fileType == ConfigFileType.DOCKERFILE) {
-        destinationFolderChooser.setText(project.getBasePath() + "/src/main/docker");
+        destinationFolderChooser.setText(project.getBasePath() +
+            AppEngineDeploymentRunConfigurationEditor.DEFAULT_DOCKERFILE_DIR);
       } else {
         destinationFolderChooser.setText(project.getBasePath());
       }


### PR DESCRIPTION
Fixes #617.

Initially, I wanted to point the browse window to config files if they exist in the usual locations (`/src/main/appengine/app.yaml` and `/src/main/docker/Dockerfile`). However, I wasn't able to find a way to direct a file chooser to a certain directory location when it opens. There was no method to achieve it.

As an alternative, this PR pre-fills the app.yaml and Dockerfile fields if they are empty and the project has these files in the usual locations. This way, the browse window will point to the existing files when opened.