### PR TITLE
Replace deprecated API to eliminate warning

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/UsersListCellRenderer.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/ui/UsersListCellRenderer.java
@@ -162,7 +162,7 @@ public class UsersListCellRenderer extends JComponent implements ListCellRendere
 
     mainPanel.add(new JLabel(new ImageIcon(scaledImage)));
     mainPanel.add(textPanel);
-    mainPanel.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, UIUtil.getBorderColor()));
+    mainPanel.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, JBColor.border()));
 
     return mainPanel;
   }


### PR DESCRIPTION
Eliminates that irritating warning in our gradle build log that we are using a deprecated API.