### PR TITLE
Make flex more info label shrinkable

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudConfigurable.form
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudConfigurable.form
@@ -57,7 +57,7 @@
       </vspacer>
       <component id="f5218" class="javax.swing.JTextPane" binding="appEngineFlexMoreInfoLabel">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="50"/>
           </grid>
         </constraints>


### PR DESCRIPTION
The problem was that the "more info label" in the server config dialog ("For more information about the App Engine flexible environment, ...") was not shrinkable. The message is very long and prevented the entire window from being resized down from both left and right sides.

This PR just marks the label "shrinkable" in the GUI designer.