### PR TITLE
Init login flow on connect / deploy

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/GoogleLoginService.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/GoogleLoginService.java
@@ -72,6 +72,8 @@ public interface GoogleLoginService {
    */
   void logIn();
 
+  void logInIfNot();
+
   /**
    * Opens an external browser to allow the user to sign in.
    * If the user is already signed in, this updates the user's credentials.

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/IntellijGoogleLoginService.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/IntellijGoogleLoginService.java
@@ -142,6 +142,13 @@ public class IntellijGoogleLoginService implements GoogleLoginService {
     logIn(null, null);
   }
 
+  @Override
+  public void logInIfNot() {
+    if(!isLoggedIn()) {
+      logIn();
+    }
+  }
+
   /**
    * Opens an external browser to allow the user to sign in.
    * If the user is already signed in, this updates the user's credentials.

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineCloudType.java
@@ -117,6 +117,8 @@ public class AppEngineCloudType extends ServerType<AppEngineServerConfiguration>
 
     @Override
     public void connect(@NotNull ConnectionCallback<AppEngineDeploymentConfiguration> callback) {
+      Services.getLoginService().logInIfNot();
+
       if (!Services.getLoginService().isLoggedIn()) {
         callback.errorOccurred(GctBundle.message("appengine.deployment.error.not.logged.in"));
       } else if (CloudSdkUtil.isCloudSdkExecutable(CloudSdkUtil.toExecutablePath(configuration.getCloudSdkHomePath()))) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineRuntimeInstance.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineRuntimeInstance.java
@@ -57,6 +57,8 @@ class AppEngineRuntimeInstance extends
       @NotNull final DeploymentOperationCallback callback) {
 
     FileDocumentManager.getInstance().saveAllDocuments();
+
+    Services.getLoginService().logInIfNot();
     if (!Services.getLoginService().isLoggedIn()) {
       callback.errorOccurred(GctBundle.message("appengine.deployment.error.not.logged.in"));
       return;


### PR DESCRIPTION
fixes #642 

Automatically inits the login flow (open up browser etc.) when the user attempts to connect or deploy when not logged in.