### PR TITLE
Restore previous active user on aborted login

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/IntellijGoogleLoginService.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/IntellijGoogleLoginService.java
@@ -169,6 +169,7 @@ public class IntellijGoogleLoginService implements GoogleLoginService {
       @Nullable final IGoogleLoginCompletedCallback callback) {
     UsageTrackerProvider
         .getInstance().trackEvent(LoginTracking.CATEGORY, LoginTracking.LOGIN, "login.start", null);
+    final CredentialedUser lastActiveUser = users.getActiveUser();
     users.removeActiveUser();
     uiFacade.notifyStatusIndicator();
 
@@ -223,8 +224,19 @@ public class IntellijGoogleLoginService implements GoogleLoginService {
           };
           users.addUser(new CredentialedUser(state, localCallback));
         }
-        else if (callback != null) {
-          callback.onLoginCompleted();
+        else {
+          // Login failed (or aborted), so restore the last active user, if any
+          restoreLastActiveUser();
+
+          if (callback != null) {
+            callback.onLoginCompleted();
+          }
+        }
+      }
+
+      private void restoreLastActiveUser() {
+        if (lastActiveUser != null) {
+          setActiveUser(lastActiveUser.getEmail());
         }
       }
     }.queue();


### PR DESCRIPTION
Fixes #644, #606 

Note: the common auth API service that performs the auth flow (opens the browser window etc.) will only do so if the user is not logged in, requiring us to log out prior to initializing the auth flow for the case of multiple accounts.

Therefore, for adding a second account when already logged in, the least invasive update is to keep a reference to the current active user and restore it if the login fails or is aborted.