### PR TITLE
Check for plugin compatibility

### DIFF
--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -110,6 +110,8 @@ Code inspections for App Engine Java code.</description>
     <localInspection language="JAVA" shortName="RestSignature" bundle="messages.EndpointBundle"  hasStaticDescription="true"
                      key="unique.rest.signature.name" groupKey="inspections.group.name" enabledByDefault="true"
                      level="ERROR" implementationClass="com.google.cloud.tools.intellij.appengine.validation.RestSignatureInspection"/>
+
+    <postStartupActivity implementation="com.google.cloud.tools.intellij.PluginCompatibilityCheck"/>
   </extensions>
 
   <extensions defaultExtensionNs="Git4Idea">

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -19,8 +19,7 @@ select.project.signin=Sign in with your Google account to list your Google Devel
 plugin.compatibility.error.title=Google Plugin Compatibility Problem
 plugin.compatibility.error.message=You are running potentially incompatible versions of the following plugins:
 plugin.compatibility.error.name.and.version={0} ({1})
-plugin.compatibility.error.update.link={0}Check{1} for updates.
-plugin.compatibility.error.plugin.link=Or, {0}manage{1} your installed plugins.
+plugin.compatibility.error.update.link=Please {0}click here{1} to ensure that you have updated all your plugins.
 
 cloud.project.label=Project\:
 appengine.flex.tools.menu.item.label=Deploy to App Engine flexible environment...

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -19,7 +19,7 @@ select.project.signin=Sign in with your Google account to list your Google Devel
 plugin.compatibility.error.title=Google Plugin Compatibility Problem
 plugin.compatibility.error.message=You are running potentially incompatible versions of the following plugins:
 plugin.compatibility.error.name.and.version={0} ({1})
-plugin.compatibility.error.update.link=Please {0}click here{1} to ensure that you have updated all your plugins.
+plugin.compatibility.error.update.link=Please {0}click here{1} to ensure that you have updated all of your plugins.
 
 cloud.project.label=Project\:
 appengine.flex.tools.menu.item.label=Deploy to App Engine flexible environment...

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -20,7 +20,7 @@ plugin.compatibility.error.title=Google Plugin Compatibility Problem
 plugin.compatibility.error.message=You are running potentially incompatible versions of the following plugins:
 plugin.compatibility.error.name.and.version={0} ({1})
 plugin.compatibility.error.update.link={0}Check{1} for updates.
-plugin.compatibility.error.plugin.link=Or, {0}manage{1} your installed plugins.</p>
+plugin.compatibility.error.plugin.link=Or, {0}manage{1} your installed plugins.
 
 cloud.project.label=Project\:
 appengine.flex.tools.menu.item.label=Deploy to App Engine flexible environment...

--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -16,6 +16,12 @@
 
 select.project.signin=Sign in with your Google account to list your Google Developers Console projects.
 
+plugin.compatibility.error.title=Google Plugin Compatibility Problem
+plugin.compatibility.error.message=You are running potentially incompatible versions of the following plugins:
+plugin.compatibility.error.name.and.version={0} ({1})
+plugin.compatibility.error.update.link={0}Check{1} for updates.
+plugin.compatibility.error.plugin.link=Or, {0}manage{1} your installed plugins.</p>
+
 cloud.project.label=Project\:
 appengine.flex.tools.menu.item.label=Deploy to App Engine flexible environment...
 appengine.cloudsdk.location.label=Cloud SDK directory\:

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/PluginCompatibilityCheck.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/PluginCompatibilityCheck.java
@@ -37,6 +37,11 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.event.HyperlinkEvent;
 
+/**
+ * A plugin post startup activity which checks to ensure that the Google Cloud Tools
+ * and Account plugins are running the same version. If there is a version mismatch, then a
+ * warning dialog is displayed with a link to check for updates.
+ */
 public class PluginCompatibilityCheck implements StartupActivity {
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/PluginCompatibilityCheck.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/PluginCompatibilityCheck.java
@@ -49,7 +49,7 @@ public class PluginCompatibilityCheck implements StartupActivity {
     checkPluginCompatibility(project);
   }
 
-  private void checkPluginCompatibility(@NotNull final Project project) {
+  private void checkPluginCompatibility(@NotNull Project project) {
     IdeaPluginDescriptor cloudToolsPlugin =
         PluginManager.getPlugin(PluginId.findId("com.google.gct.core"));
     IdeaPluginDescriptor accountPlugin =

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/PluginCompatibilityCheck.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/PluginCompatibilityCheck.java
@@ -57,7 +57,7 @@ public class PluginCompatibilityCheck implements StartupActivity {
     String cloudToolsPluginVersion = cloudToolsPlugin.getVersion();
     String accountPluginVersion = accountPlugin.getVersion();
 
-    if (accountPluginVersion.equals(cloudToolsPluginVersion)) {
+    if (!accountPluginVersion.equals(cloudToolsPluginVersion)) {
       NotificationGroup notification = new NotificationGroup(
           GctBundle.message("plugin.compatibility.error.title"),
           NotificationDisplayType.BALLOON, true);

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/PluginCompatibilityCheck.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/PluginCompatibilityCheck.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij;
+
+
+import com.google.cloud.tools.intellij.util.GctBundle;
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
+import com.intellij.ide.plugins.PluginManagerConfigurable;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationListener;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.updateSettings.impl.UpdateChecker;
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.event.HyperlinkEvent;
+
+public class PluginCompatibilityCheck implements StartupActivity {
+
+  @Override
+  public void runActivity(@NotNull Project project) {
+    checkPluginCompatibility(project);
+  }
+
+  private void checkPluginCompatibility(@NotNull final Project project) {
+    IdeaPluginDescriptor cloudToolsPlugin =
+        PluginManager.getPlugin(PluginId.findId("com.google.gct.core"));
+    IdeaPluginDescriptor accountPlugin =
+        PluginManager.getPlugin(PluginId.findId("com.google.gct.login"));
+
+    if (cloudToolsPlugin == null || accountPlugin == null) {
+      return;
+    }
+
+    String cloudToolsPluginVersion = cloudToolsPlugin.getVersion();
+    String accountPluginVersion = accountPlugin.getVersion();
+
+    if (accountPluginVersion.equals(cloudToolsPluginVersion)) {
+      NotificationGroup notification = new NotificationGroup(
+          GctBundle.message("plugin.compatibility.error.title"),
+          NotificationDisplayType.BALLOON, true);
+
+      StringBuilder errorMessage = new StringBuilder();
+
+      errorMessage.append("<p>");
+      errorMessage.append(GctBundle.message("plugin.compatibility.error.message"));
+      errorMessage.append("<p/>");
+
+
+      errorMessage.append("<ul>");
+      errorMessage.append("<li>");
+      errorMessage.append(
+          GctBundle.message(
+              "plugin.compatibility.error.name.and.version",
+              cloudToolsPlugin.getName(),
+              cloudToolsPluginVersion));
+      errorMessage.append("</li>");
+      errorMessage.append("<li>");
+      errorMessage.append(
+          GctBundle.message(
+              "plugin.compatibility.error.name.and.version",
+              accountPlugin.getName(),
+              accountPluginVersion));
+      errorMessage.append("</li>");
+      errorMessage.append("</ul>");
+
+      errorMessage.append("<br />");
+
+      errorMessage.append("<p>");
+      errorMessage.append(
+          GctBundle.message(
+              "plugin.compatibility.error.update.link", "<a href=\"#update\">", "</a>"));
+      errorMessage.append("</p>");
+
+      errorMessage.append("<p>");
+      errorMessage.append
+          (GctBundle.message(
+              "plugin.compatibility.error.plugin.link", "<a href=\"#manage\">", "</a>"));
+      errorMessage.append("</p>");
+
+      notification.createNotification(
+          GctBundle.message("plugin.compatibility.error.title"),
+          errorMessage.toString(),
+          NotificationType.ERROR, new PluginCompatibilityLinkListener(project)).notify(project);
+    }
+  }
+
+  private static class PluginCompatibilityLinkListener implements NotificationListener {
+    private Project project;
+
+    public PluginCompatibilityLinkListener(@NotNull final Project project) {
+      this.project = project;
+    }
+
+    @Override
+    public void hyperlinkUpdate(@NotNull Notification notification,
+        @NotNull HyperlinkEvent event) {
+      String href = event.getDescription();
+
+      if ("#update".equals(href)) {
+        UpdateChecker.updateAndShowResult(project, null);
+      } else if ("#manage".equals(href)) {
+        ShowSettingsUtil.getInstance().showSettingsDialog(project,
+            PluginManagerConfigurable.class);
+      }
+    }
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/PluginCompatibilityCheck.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/PluginCompatibilityCheck.java
@@ -94,12 +94,6 @@ public class PluginCompatibilityCheck implements StartupActivity {
               "plugin.compatibility.error.update.link", "<a href=\"#update\">", "</a>"));
       errorMessage.append("</p>");
 
-      errorMessage.append("<p>");
-      errorMessage.append
-          (GctBundle.message(
-              "plugin.compatibility.error.plugin.link", "<a href=\"#manage\">", "</a>"));
-      errorMessage.append("</p>");
-
       notification.createNotification(
           GctBundle.message("plugin.compatibility.error.title"),
           errorMessage.toString(),


### PR DESCRIPTION
fixes #650 

Adds a notification window if plugin versions are not equal:

![image](https://cloud.githubusercontent.com/assets/1735744/14795185/4c351b9e-0af5-11e6-834c-f40a42e86255.png)

Todo: finalize and externalize wording.

Note: the check is owned by the cloud tools plugin. Once this is pushed out and users update their plugin, any subsequent plugin updates where the versions are mismatched will show this warning.