### PR TITLE
Restore user specified source path when IDE init

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/UserSpecifiedPathDeploymentSourceType.java
@@ -61,6 +61,7 @@ public class UserSpecifiedPathDeploymentSourceType extends
           AppEngineDeploymentConfiguration.USER_SPECIFIED_ARTIFACT_PATH_ATTRIBUTE);
 
       if (!StringUtil.isEmpty(filePath)) {
+        userSpecifiedSource.setFilePath(filePath);
         userSpecifiedSource.setName(
             GctBundle.message(
                 "appengine.flex.user.specified.deploymentsource.name.with.filename",


### PR DESCRIPTION
Fixes #682.

The file path value was previously empty. So, after restarting IJ, clicking on the play button for a saved deploy config that uses a custom WAR/JAR was failing.

(However, interestingly, the value was displayed correctly when a config window was opened.)