### PR TITLE
Validation order

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.intellij.login.CredentialedUser;
 import com.google.cloud.tools.intellij.ui.BrowserOpeningHyperLinkListener;
 import com.google.cloud.tools.intellij.ui.PlaceholderTextField;
 import com.google.cloud.tools.intellij.util.GctBundle;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
@@ -220,6 +221,8 @@ public class AppEngineDeploymentRunConfigurationEditor extends
   @Override
   protected void applyEditorTo(AppEngineDeploymentConfiguration configuration)
       throws ConfigurationException {
+    validateConfiguration();
+
     configuration.setCloudProjectName(projectSelector.getText());
     CredentialedUser selectedUser = projectSelector.getSelectedUser();
     if (selectedUser != null) {
@@ -235,7 +238,16 @@ public class AppEngineDeploymentRunConfigurationEditor extends
 
     setDeploymentSourceName(configuration.getUserSpecifiedArtifactPath());
     updateJarWarSelector();
-    validateConfiguration();
+  }
+
+  @VisibleForTesting
+  JComboBox getConfigTypeComboBox() {
+    return configTypeComboBox;
+  }
+
+  @VisibleForTesting
+  void setProjectSelector(ProjectSelector projectSelector) {
+    this.projectSelector = projectSelector;
   }
 
   private void updateJarWarSelector() {

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.cloud;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.tools.intellij.appengine.cloud.AppEngineDeploymentConfiguration.ConfigType;
+import com.google.cloud.tools.intellij.elysium.ProjectSelector;
+
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
+import com.intellij.testFramework.PlatformTestCase;
+
+public class AppEngineDeploymentRunConfigurationEditorTest extends PlatformTestCase {
+
+  private AppEngineDeploymentRunConfigurationEditor editor;
+  private DeploymentSource deploymentSource;
+  private AppEngineHelper appEngineHelper;
+  private ProjectSelector projectSelector;
+
+  private static final String PROJECT_NAME = "test-proj";
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    deploymentSource = mock(DeploymentSource.class);
+    when(deploymentSource.isValid()).thenReturn(true);
+
+    appEngineHelper = mock(AppEngineHelper.class);
+
+    projectSelector = mock(ProjectSelector.class);
+    when(projectSelector.getText()).thenReturn(PROJECT_NAME);
+  }
+
+  public void testValidSelections() {
+    editor = new AppEngineDeploymentRunConfigurationEditor(
+        getProject(), deploymentSource, appEngineHelper);
+
+    editor.setProjectSelector(projectSelector);
+
+    AppEngineDeploymentConfiguration config = new AppEngineDeploymentConfiguration();
+    config.setCloudProjectName("test-cloud-proj");
+    config.setConfigType(ConfigType.AUTO);
+
+    try {
+      editor.applyEditorTo(config);
+    } catch (ConfigurationException ce) {
+      fail("No validation error expected");
+    }
+  }
+
+  public void testOnValidationFailure_configIsNotUpdated() {
+    editor = new AppEngineDeploymentRunConfigurationEditor(
+        getProject(), deploymentSource, appEngineHelper);
+
+    editor.setProjectSelector(projectSelector);
+
+    AppEngineDeploymentConfiguration config = new AppEngineDeploymentConfiguration();
+
+    // Simulate updating the config type in the UI then saving with an invalid configuration.
+    // The resultant configuration should not contain the update.
+
+    editor.getConfigTypeComboBox().setSelectedItem(ConfigType.CUSTOM);
+
+    try {
+      editor.applyEditorTo(config);
+      fail("Expected validation failure");
+    } catch (ConfigurationException ce) {
+      assertEquals(ConfigType.AUTO, config.getConfigType());
+    }
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+    editor.dispose();
+  }
+}


### PR DESCRIPTION
fixes #679
migrated from  #684

Performs validation before saving the settings.

Note that doesn't affect the state of the deployment source when clicking 'ok' / 'apply' with a validation error. This only affects the portion of the deployment config where an extension point is provided, e.g. everything other than the name, server, and deployment.