### PR TITLE
Fix memory leak

### DIFF
--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditorTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.intellij.appengine.cloud.AppEngineDeploymentConfig
 import com.google.cloud.tools.intellij.elysium.ProjectSelector;
 
 import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
 import com.intellij.testFramework.PlatformTestCase;
 
@@ -89,6 +90,6 @@ public class AppEngineDeploymentRunConfigurationEditorTest extends PlatformTestC
   @Override
   protected void tearDown() throws Exception {
     super.tearDown();
-    editor.dispose();
+    Disposer.dispose(editor);
   }
 }

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditorTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditorTest.java
@@ -47,14 +47,14 @@ public class AppEngineDeploymentRunConfigurationEditorTest extends PlatformTestC
 
     projectSelector = mock(ProjectSelector.class);
     when(projectSelector.getText()).thenReturn(PROJECT_NAME);
-  }
 
-  public void testValidSelections() {
     editor = new AppEngineDeploymentRunConfigurationEditor(
         getProject(), deploymentSource, appEngineHelper);
 
     editor.setProjectSelector(projectSelector);
+  }
 
+  public void testValidSelections() {
     AppEngineDeploymentConfiguration config = new AppEngineDeploymentConfiguration();
     config.setCloudProjectName("test-cloud-proj");
     config.setConfigType(ConfigType.AUTO);
@@ -67,16 +67,10 @@ public class AppEngineDeploymentRunConfigurationEditorTest extends PlatformTestC
   }
 
   public void testOnValidationFailure_configIsNotUpdated() {
-    editor = new AppEngineDeploymentRunConfigurationEditor(
-        getProject(), deploymentSource, appEngineHelper);
-
-    editor.setProjectSelector(projectSelector);
-
     AppEngineDeploymentConfiguration config = new AppEngineDeploymentConfiguration();
 
     // Simulate updating the config type in the UI then saving with an invalid configuration.
     // The resultant configuration should not contain the update.
-
     editor.getConfigTypeComboBox().setSelectedItem(ConfigType.CUSTOM);
 
     try {


### PR DESCRIPTION
Fixes #689.

Use `Disposer.dispose()` to properly dispose an editor.

I also took the liberty to refactor common code into `setup()`. @etanshaul, what do you think?