### PR TITLE
Migrate sending metrics to Cloud-platform-wide Google Analytics

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -56,7 +56,7 @@ public class GoogleUsageTracker implements UsageTracker {
     this.analyticsId = UsageTrackerManager.getInstance().getAnalyticsProperty();
   }
 
-  private static final List<? extends NameValuePair> analyticsBaseData = ImmutableList
+  private static final List<BasicNameValuePair> analyticsBaseData = ImmutableList
       .of(new BasicNameValuePair("v", "1"),         // Protocol version
           new BasicNameValuePair("t", "pageview"),  // Note the "pageview" type, not "event"
           new BasicNameValuePair("ni", "0"),        // Non-interactive? Report as interactive.

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -102,7 +102,7 @@ public class GoogleUsageTracker implements UsageTracker {
         postData.add(new BasicNameValuePair("dp", virtualPageUrl));
         if (eventLabel != null) {
           // Event metadata are passed as a (virtual) page title.
-          String virtualPageTitle = eventLabel + "\\=" + (eventValue != null ? eventValue : "null");
+          String virtualPageTitle = eventLabel + "=" + (eventValue != null ? eventValue : "null");
           postData.add(new BasicNameValuePair("dt", virtualPageTitle));
         }
 

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -77,10 +77,6 @@ public class GoogleUsageTracker implements UsageTracker {
       @NotNull String eventAction,
       @Nullable String eventLabel,
       @Nullable Integer eventValue) {
-    if (eventValue != null) {
-      Preconditions.checkArgument(eventLabel != null);
-    }
-
     if (!ApplicationManager.getApplication().isUnitTestMode()) {
       if (UsageTrackerManager.getInstance().isTrackingEnabled()) {
         // For the semantics of each parameter, consult the followings:

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.intellij.stats;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -64,12 +64,6 @@ public class GoogleUsageTracker implements UsageTracker {
 
   /**
    * Send a (virtual) "pageview" ping to the Cloud-platform-wide Google Analytics Property.
-   *
-   * @param eventCategory Ignored for plugins installed on IntelliJ. Retained to maintain backward
-   *     compatibility on Android Studio.
-   * @param eventAction On IntelliJ, this is the primary event action.
-   * @param eventLabel On IntelliJ, reported as a metadata key.
-   * @param eventValue On IntelliJ, reported as a metadata value.
    */
   @Override
   public void trackEvent(@NotNull String eventCategory,
@@ -86,7 +80,7 @@ public class GoogleUsageTracker implements UsageTracker {
         List<BasicNameValuePair> postData = Lists.newArrayList(analyticsBaseData);
         postData.add(new BasicNameValuePair("tid", analyticsId));
 
-        postData.add(new BasicNameValuePair("cd19", ANALYTICS_APP));  // Event type
+        postData.add(new BasicNameValuePair("cd19", eventCategory));  // Event type
         postData.add(new BasicNameValuePair("cd20", eventAction));  // Event name
         postData.add(new BasicNameValuePair("cd16", "0"));  // Internal user? No.
         postData.add(new BasicNameValuePair("cd17", "0"));  // User signed in? We will ignore this.

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTrackerManager.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/UsageTrackerManager.java
@@ -30,16 +30,16 @@ import org.jetbrains.annotations.Nullable;
  */
 // TODO: Refactor to an IntelliJ service
 public final class UsageTrackerManager {
-  public static final String USAGE_TRACKER_KEY = "GOOGLE_CLOUD_TOOLS_USAGE_TRACKER_OPT_IN";
   @VisibleForTesting
-  protected static final String USAGE_TRACKER_PROPERTY_PLACEHOLDER = "${usageTrackerProperty}";
+  static final String USAGE_TRACKER_KEY = "GOOGLE_CLOUD_TOOLS_USAGE_TRACKER_OPT_IN";
+  @VisibleForTesting
+  static final String USAGE_TRACKER_PROPERTY_PLACEHOLDER = "${usageTrackerProperty}";
   private static UsageTrackerManager instance;
   private PropertiesComponent datastore;
   private PluginFlags flags;
   private static final Object factoryLock = new Object();
 
-  @VisibleForTesting
-  UsageTrackerManager() {
+  private UsageTrackerManager() {
     datastore = PropertiesComponent.getInstance();
     flags = new PropertiesFilePluginFlags();
   }
@@ -93,7 +93,7 @@ public final class UsageTrackerManager {
   @Nullable
   protected String getAnalyticsProperty() {
     String analyticsId = flags.getAnalyticsId();
-    if (analyticsId != null && !USAGE_TRACKER_PROPERTY_PLACEHOLDER.equals(analyticsId)) {
+    if (!USAGE_TRACKER_PROPERTY_PLACEHOLDER.equals(analyticsId)) {
       return analyticsId;
     }
     return null;


### PR DESCRIPTION
Fixes #693.

I tried to re-use the existing facilities for sending usage data as much as possible. In the long run, we would probably want to overhaul this.

I will be doing actual ping tests in various ways.