### PR TITLE
Save and load artifact deployment source types

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/CloudToolsPluginInitializationComponent.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/CloudToolsPluginInitializationComponent.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.intellij;
 
+import com.google.cloud.tools.intellij.appengine.cloud.AppEngineArtifactDeploymentSourceType;
 import com.google.cloud.tools.intellij.appengine.cloud.AppEngineCloudType;
 import com.google.cloud.tools.intellij.appengine.cloud.AppEngineToolsMenuAction;
 import com.google.cloud.tools.intellij.appengine.cloud.MavenBuildDeploymentSourceType;
@@ -63,7 +64,7 @@ public class CloudToolsPluginInitializationComponent implements ApplicationCompo
     }
 
     if (pluginInfoService.shouldEnable(GctFeature.APPENGINE_FLEX)) {
-      initAppEngineFlex(pluginConfigurationService);
+      initAppEngineSupport(pluginConfigurationService);
     }
 
     if (pluginInfoService.shouldEnableErrorFeedbackReporting()) {
@@ -77,7 +78,7 @@ public class CloudToolsPluginInitializationComponent implements ApplicationCompo
             ConfigurationType.CONFIGURATION_TYPE_EP, new CloudDebugConfigType());
   }
 
-  private void initAppEngineFlex(CloudToolsPluginConfigurationService pluginConfigurationService) {
+  private void initAppEngineSupport(CloudToolsPluginConfigurationService pluginConfigurationService) {
     AppEngineCloudType appEngineCloudType = new AppEngineCloudType();
     pluginConfigurationService.registerExtension(ServerType.EP_NAME, appEngineCloudType);
     pluginConfigurationService.registerExtension(ConfigurationType.CONFIGURATION_TYPE_EP,
@@ -86,6 +87,8 @@ public class CloudToolsPluginInitializationComponent implements ApplicationCompo
         new UserSpecifiedPathDeploymentSourceType());
     pluginConfigurationService.registerExtension(DeploymentSourceType.EP_NAME,
         new MavenBuildDeploymentSourceType());
+    pluginConfigurationService.registerExtension(DeploymentSourceType.EP_NAME,
+        new AppEngineArtifactDeploymentSourceType());
 
     ActionManager actionManager = ActionManager.getInstance();
     AnAction toolsMenuAction = new AppEngineToolsMenuAction();

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/CloudToolsPluginInitializationComponent.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/CloudToolsPluginInitializationComponent.java
@@ -78,7 +78,8 @@ public class CloudToolsPluginInitializationComponent implements ApplicationCompo
             ConfigurationType.CONFIGURATION_TYPE_EP, new CloudDebugConfigType());
   }
 
-  private void initAppEngineSupport(CloudToolsPluginConfigurationService pluginConfigurationService) {
+  private void initAppEngineSupport(
+      CloudToolsPluginConfigurationService pluginConfigurationService) {
     AppEngineCloudType appEngineCloudType = new AppEngineCloudType();
     pluginConfigurationService.registerExtension(ServerType.EP_NAME, appEngineCloudType);
     pluginConfigurationService.registerExtension(ConfigurationType.CONFIGURATION_TYPE_EP,

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.intellij.appengine.cloud;
 
 import com.intellij.packaging.artifacts.ArtifactPointer;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSourceType;
 import com.intellij.remoteServer.impl.configuration.deployment.ArtifactDeploymentSourceImpl;
 
 import org.jetbrains.annotations.NotNull;
@@ -29,6 +30,13 @@ public class AppEngineArtifactDeploymentSource extends ArtifactDeploymentSourceI
     implements AppEngineDeployable {
 
   private AppEngineEnvironment environment;
+
+  /**
+   * Default constructor used instantiating plain Artifact Deployment sources
+   */
+  public AppEngineArtifactDeploymentSource(@NotNull ArtifactPointer pointer) {
+    super(pointer);
+  }
 
   /**
    * Initialize the artifact deployment source given a target App Engine environment, and an
@@ -44,5 +52,11 @@ public class AppEngineArtifactDeploymentSource extends ArtifactDeploymentSourceI
   @Override
   public AppEngineEnvironment getEnvironment() {
     return environment;
+  }
+
+  @NotNull
+  @Override
+  public AppEngineArtifactDeploymentSourceType getType() {
+    return DeploymentSourceType.EP_NAME.findExtension(AppEngineArtifactDeploymentSourceType.class);
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSource.java
@@ -32,7 +32,7 @@ public class AppEngineArtifactDeploymentSource extends ArtifactDeploymentSourceI
   private AppEngineEnvironment environment;
 
   /**
-   * Default constructor used instantiating plain Artifact Deployment sources
+   * Default constructor used instantiating plain Artifact Deployment sources.
    */
   public AppEngineArtifactDeploymentSource(@NotNull ArtifactPointer pointer) {
     super(pointer);

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSourceType.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.intellij.appengine.cloud;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.packaging.artifacts.Artifact;
+import com.intellij.packaging.artifacts.ArtifactManager;
+import com.intellij.packaging.artifacts.ArtifactPointerManager;
+import com.intellij.remoteServer.configuration.deployment.ArtifactDeploymentSource;
+import com.intellij.remoteServer.configuration.deployment.DeploymentSourceType;
+import com.intellij.remoteServer.impl.configuration.deployment.DeployToServerRunConfiguration;
+
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+/**
+ * A {@link DeploymentSourceType} loading and saving of a {@link AppEngineArtifactDeploymentSource}.
+ */
+public class AppEngineArtifactDeploymentSourceType
+    extends DeploymentSourceType<ArtifactDeploymentSource> {
+
+  private static final String SOURCE_TYPE_ID = "appengine-artifact-source";
+  private static final String NAME_ATTRIBUTE = "name";
+
+  public AppEngineArtifactDeploymentSourceType() {
+    super(SOURCE_TYPE_ID);
+  }
+
+  @NotNull
+  @Override
+  public AppEngineArtifactDeploymentSource load(@NotNull Element tag, @NotNull Project project) {
+    final String name = tag.getAttributeValue(NAME_ATTRIBUTE);
+
+    Artifact[] artifacts = ArtifactManager.getInstance(project).getArtifacts();
+    Optional<Artifact> artifact = Iterables.tryFind(Arrays.asList(artifacts),
+        new Predicate<Artifact>() {
+          @Override
+          public boolean apply(Artifact artifact) {
+            return artifact.getName().equals(name);
+          }
+        }
+    );
+
+    Element settings = tag.getChild(DeployToServerRunConfiguration.SETTINGS_ELEMENT);
+
+    if (artifact.isPresent() && settings != null) {
+      String environment = settings.getAttributeValue(
+          AppEngineDeploymentConfiguration.ENVIRONMENT_ATTRIBUTE);
+
+      return new AppEngineArtifactDeploymentSource(
+          AppEngineEnvironment.valueOf(environment),
+          ArtifactPointerManager.getInstance(project).createPointer(artifact.get()));
+    } else {
+      return new AppEngineArtifactDeploymentSource(
+          ArtifactPointerManager.getInstance(project)
+              .createPointer(tag.getAttributeValue(NAME_ATTRIBUTE)));
+    }
+  }
+
+  @Override
+  public void save(@NotNull ArtifactDeploymentSource deploymentSource,
+      @NotNull Element tag) {
+    tag.setAttribute(NAME_ATTRIBUTE, deploymentSource.getPresentableName());
+  }
+}

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSourceType.java
@@ -49,32 +49,32 @@ public class AppEngineArtifactDeploymentSourceType
   @NotNull
   @Override
   public AppEngineArtifactDeploymentSource load(@NotNull Element tag, @NotNull Project project) {
-    final String name = tag.getAttributeValue(NAME_ATTRIBUTE);
-
-    Artifact[] artifacts = ArtifactManager.getInstance(project).getArtifacts();
-    Optional<Artifact> artifact = Iterables.tryFind(Arrays.asList(artifacts),
-        new Predicate<Artifact>() {
-          @Override
-          public boolean apply(Artifact artifact) {
-            return artifact.getName().equals(name);
-          }
-        }
-    );
-
+    final String artifactName = tag.getAttributeValue(NAME_ATTRIBUTE);
     Element settings = tag.getChild(DeployToServerRunConfiguration.SETTINGS_ELEMENT);
 
-    if (artifact.isPresent() && settings != null) {
-      String environment = settings.getAttributeValue(
-          AppEngineDeploymentConfiguration.ENVIRONMENT_ATTRIBUTE);
+    if (settings != null) {
+      Artifact[] artifacts = ArtifactManager.getInstance(project).getArtifacts();
+      Optional<Artifact> artifact = Iterables.tryFind(Arrays.asList(artifacts),
+          new Predicate<Artifact>() {
+            @Override
+            public boolean apply(Artifact artifact) {
+              return artifact.getName().equals(artifactName);
+            }
+          }
+      );
 
-      return new AppEngineArtifactDeploymentSource(
-          AppEngineEnvironment.valueOf(environment),
-          ArtifactPointerManager.getInstance(project).createPointer(artifact.get()));
-    } else {
-      return new AppEngineArtifactDeploymentSource(
-          ArtifactPointerManager.getInstance(project)
-              .createPointer(tag.getAttributeValue(NAME_ATTRIBUTE)));
+      if (artifact.isPresent()) {
+        String environment = settings.getAttributeValue(
+            AppEngineDeploymentConfiguration.ENVIRONMENT_ATTRIBUTE);
+
+        return new AppEngineArtifactDeploymentSource(
+            AppEngineEnvironment.valueOf(environment),
+            ArtifactPointerManager.getInstance(project).createPointer(artifact.get()));
+      }
     }
+
+    return new AppEngineArtifactDeploymentSource(
+        ArtifactPointerManager.getInstance(project).createPointer(artifactName));
   }
 
   @Override

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
@@ -47,9 +47,11 @@ public class AppEngineDeploymentConfiguration extends
   }
 
   public static final String USER_SPECIFIED_ARTIFACT_PATH_ATTRIBUTE = "userSpecifiedArtifactPath";
+  public static final String ENVIRONMENT_ATTRIBUTE = "environment";
 
   private String cloudProjectName;
   private String googleUsername;
+  private String environment;
   private String dockerFilePath;
   private String appYamlPath;
   private boolean userSpecifiedArtifact;
@@ -65,6 +67,11 @@ public class AppEngineDeploymentConfiguration extends
   @Attribute("googleUsername")
   public String getGoogleUsername() {
     return googleUsername;
+  }
+
+  @Attribute(ENVIRONMENT_ATTRIBUTE)
+  public String getEnvironment() {
+    return environment;
   }
 
   @Attribute("userSpecifiedArtifact")
@@ -107,6 +114,10 @@ public class AppEngineDeploymentConfiguration extends
 
   public void setGoogleUsername(String googleUsername) {
     this.googleUsername = googleUsername;
+  }
+
+  public void setEnvironment(String environment) {
+    this.environment = environment;
   }
 
   public void setUserSpecifiedArtifact(boolean userSpecifiedArtifact) {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -95,6 +95,7 @@ public class AppEngineDeploymentRunConfigurationEditor extends
   private JPanel appEngineFlexConfigPanel;
 
   private DeploymentSource deploymentSource;
+  private AppEngineEnvironment environment;
 
   private static final String COST_WARNING_OPEN_TAG = "<html><font face='sans' size='-1'><i>";
   private static final String COST_WARNING_CLOSE_TAG = "</i></font></html>";
@@ -118,7 +119,7 @@ public class AppEngineDeploymentRunConfigurationEditor extends
     updateJarWarSelector();
     userSpecifiedArtifactFileSelector.setVisible(true);
 
-    AppEngineEnvironment environment = deploymentSource.getEnvironment();
+    environment = deploymentSource.getEnvironment();
 
     if (environment == AppEngineEnvironment.APP_ENGINE_FLEX) {
       appEngineCostWarningLabel.setText(
@@ -220,6 +221,8 @@ public class AppEngineDeploymentRunConfigurationEditor extends
   @Override
   protected void resetEditorFrom(AppEngineDeploymentConfiguration configuration) {
     projectSelector.setText(configuration.getCloudProjectName());
+    environmentLabel.setText(
+        AppEngineEnvironment.valueOf(configuration.getEnvironment()).localizedLabel());
     userSpecifiedArtifactFileSelector.setText(configuration.getUserSpecifiedArtifactPath());
     dockerFilePathField.setText(configuration.getDockerFilePath());
     appYamlPathField.setText(configuration.getAppYamlPath());
@@ -242,6 +245,7 @@ public class AppEngineDeploymentRunConfigurationEditor extends
     if (selectedUser != null) {
       configuration.setGoogleUsername(selectedUser.getEmail());
     }
+    configuration.setEnvironment(environment.name());
     configuration.setUserSpecifiedArtifact(isUserSpecifiedPathDeploymentSource());
     configuration.setUserSpecifiedArtifactPath(userSpecifiedArtifactFileSelector.getText());
     configuration.setDockerFilePath(dockerFilePathField.getText());


### PR DESCRIPTION
fixes #729 

@patflynn, @chanseokoh 

This error occurs when deployment configurations containing an AE artifact deployment sources are created. Once these configurations are created, if the user closes the project and then attempts to reload the configuration, this fix will correctly recreate the artifact from the serialized state that was saved by the IDE. Without this fix, the `AppEngineArtifactDeploymentSource` will not be recreated - only its platform supplied superclass - which will miss out on AE specific details such as environment, and cause downstream errors during deployment.