### PR TITLE
Don't set environment in resetEditorFrom()

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentConfiguration.java
@@ -51,7 +51,15 @@ public class AppEngineDeploymentConfiguration extends
 
   private String cloudProjectName;
   private String googleUsername;
+
+  /**
+   * Environment is stored here in order to restore the environment when this configuration is
+   * deserialized. At deserialization time, we cannot resolve the environment via the normal means
+   * of inspecting the Project's modules and artifacts because this happens before the modules have
+   * been loaded.
+   */
   private String environment;
+
   private String dockerFilePath;
   private String appYamlPath;
   private boolean userSpecifiedArtifact;

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -221,8 +221,6 @@ public class AppEngineDeploymentRunConfigurationEditor extends
   @Override
   protected void resetEditorFrom(AppEngineDeploymentConfiguration configuration) {
     projectSelector.setText(configuration.getCloudProjectName());
-    environmentLabel.setText(
-        AppEngineEnvironment.valueOf(configuration.getEnvironment()).localizedLabel());
     userSpecifiedArtifactFileSelector.setText(configuration.getUserSpecifiedArtifactPath());
     dockerFilePathField.setText(configuration.getDockerFilePath());
     appYamlPathField.setText(configuration.getAppYamlPath());


### PR DESCRIPTION
fixes #738 

Since we are explicitly passing in the environment to the Editor constructor, there is no need to reset it from the configuration.