### PR TITLE
Track deploy and stop task execution events

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineFlexibleDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineFlexibleDeployTask.java
@@ -17,7 +17,9 @@
 package com.google.cloud.tools.intellij.appengine.cloud;
 
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
+import com.google.cloud.tools.intellij.stats.UsageTrackerProvider;
 import com.google.cloud.tools.intellij.util.GctBundle;
+import com.google.cloud.tools.intellij.util.GctTracking;
 
 import com.intellij.openapi.diagnostic.Logger;
 
@@ -43,6 +45,11 @@ public class AppEngineFlexibleDeployTask implements AppEngineTask {
 
   @Override
   public void execute(ProcessStartListener startListener) {
+    UsageTrackerProvider.getInstance()
+        .trackEvent(GctTracking.CATEGORY, GctTracking.APP_ENGINE_DEPLOY,
+            "flex." + (deploy.getDeploymentConfiguration().isAuto() ? "auto" : "custom"),
+            null);
+
     File stagingDirectory;
 
     try {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineRunner.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineRunner.java
@@ -17,6 +17,8 @@
 package com.google.cloud.tools.intellij.appengine.cloud;
 
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
+import com.google.cloud.tools.intellij.stats.UsageTrackerProvider;
+import com.google.cloud.tools.intellij.util.GctTracking;
 
 import com.intellij.openapi.vcs.impl.CancellableRunnable;
 
@@ -44,6 +46,9 @@ public class AppEngineRunner implements CancellableRunnable {
 
   @Override
   public void cancel() {
+    UsageTrackerProvider.getInstance()
+        .trackEvent(GctTracking.CATEGORY, GctTracking.APP_ENGINE_DEPLOY_CANCEL, null, null);
+
     if (process != null) {
       process.destroy();
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStandardDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStandardDeployTask.java
@@ -58,7 +58,7 @@ public class AppEngineStandardDeployTask implements AppEngineTask {
   public void execute(ProcessStartListener startListener) {
     UsageTrackerProvider.getInstance()
         .trackEvent(GctTracking.CATEGORY, GctTracking.APP_ENGINE_DEPLOY,
-            isFlexCompat ? "flex.compat" : "standard", null);
+            isFlexCompat ? "flex-compat" : "standard", null);
 
     File stagingDirectory;
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStandardDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStandardDeployTask.java
@@ -18,7 +18,9 @@ package com.google.cloud.tools.intellij.appengine.cloud;
 
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessExitListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
+import com.google.cloud.tools.intellij.stats.UsageTrackerProvider;
 import com.google.cloud.tools.intellij.util.GctBundle;
+import com.google.cloud.tools.intellij.util.GctTracking;
 import com.google.common.annotations.VisibleForTesting;
 
 import com.intellij.openapi.diagnostic.Logger;
@@ -37,16 +39,27 @@ public class AppEngineStandardDeployTask implements AppEngineTask {
 
   private AppEngineDeploy deploy;
   private AppEngineStandardStage stageStandard;
+  private boolean isFlexCompat;
 
+  /**
+   * @param isFlexCompat does not change any behavior of actual deployment. Provided solely
+   *     for the purpose of Analytics usage reporting.
+   */
   public AppEngineStandardDeployTask(
       @NotNull AppEngineDeploy deploy,
-      @NotNull AppEngineStandardStage stageStandard) {
+      @NotNull AppEngineStandardStage stageStandard,
+      boolean isFlexCompat) {
     this.deploy = deploy;
     this.stageStandard = stageStandard;
+    this.isFlexCompat = isFlexCompat;
   }
 
   @Override
   public void execute(ProcessStartListener startListener) {
+    UsageTrackerProvider.getInstance()
+        .trackEvent(GctTracking.CATEGORY, GctTracking.APP_ENGINE_DEPLOY,
+            isFlexCompat ? "flex.compat" : "standard", null);
+
     File stagingDirectory;
 
     try {

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStopTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStopTask.java
@@ -17,7 +17,9 @@
 package com.google.cloud.tools.intellij.appengine.cloud;
 
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
+import com.google.cloud.tools.intellij.stats.UsageTrackerProvider;
 import com.google.cloud.tools.intellij.util.GctBundle;
+import com.google.cloud.tools.intellij.util.GctTracking;
 
 import com.intellij.openapi.diagnostic.Logger;
 
@@ -42,6 +44,9 @@ public class AppEngineStopTask implements AppEngineTask {
 
   @Override
   public void execute(ProcessStartListener startListener) {
+    UsageTrackerProvider.getInstance()
+        .trackEvent(GctTracking.CATEGORY, GctTracking.APP_ENGINE_STOP, null, null);
+
     try {
       stop.getHelper().stageCredentials(stop.getDeploymentConfiguration().getGoogleUsername());
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -137,16 +137,12 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
         targetEnvironment,
         wrapCallbackForUsageTracking(callback, deploymentConfiguration, targetEnvironment));
 
-    if (targetEnvironment.isStandard()) {
-      return createStandardRunner(loggingHandler, source.getFile(), deploy,
-          false); // not flex compat (usage tracking purpose)
+    boolean isFlexCompat =
+        targetEnvironment.isFlexible() && AppEngineUtil.isFlexCompat(project, source);
+    if (targetEnvironment.isStandard() || isFlexCompat) {
+      return createStandardRunner(loggingHandler, source.getFile(), deploy, isFlexCompat);
     } else if (targetEnvironment.isFlexible()) {
-      if (AppEngineUtil.isFlexCompat(project, source)) {
-        return createStandardRunner(loggingHandler, source.getFile(), deploy,
-            true); // flex compat (usage tracking purpose)
-      } else {
-        return createFlexRunner(loggingHandler, source.getFile(), deploymentConfiguration, deploy);
-      }
+      return createFlexRunner(loggingHandler, source.getFile(), deploymentConfiguration, deploy);
     } else {
       throw new AssertionError("Invalid App Engine target environment: " + targetEnvironment);
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/CloudSdkAppEngineHelper.java
@@ -137,11 +137,16 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
         targetEnvironment,
         wrapCallbackForUsageTracking(callback, deploymentConfiguration, targetEnvironment));
 
-    if (targetEnvironment.isStandard()
-        || (targetEnvironment.isFlexible() && AppEngineUtil.isFlexCompat(project, source))) {
-      return createStandardRunner(loggingHandler, source.getFile(), deploy);
+    if (targetEnvironment.isStandard()) {
+      return createStandardRunner(loggingHandler, source.getFile(), deploy,
+          false); // not flex compat (usage tracking purpose)
     } else if (targetEnvironment.isFlexible()) {
-      return createFlexRunner(loggingHandler, source.getFile(), deploymentConfiguration, deploy);
+      if (AppEngineUtil.isFlexCompat(project, source)) {
+        return createStandardRunner(loggingHandler, source.getFile(), deploy,
+            true); // flex compat (usage tracking purpose)
+      } else {
+        return createFlexRunner(loggingHandler, source.getFile(), deploymentConfiguration, deploy);
+      }
     } else {
       throw new AssertionError("Invalid App Engine target environment: " + targetEnvironment);
     }
@@ -150,13 +155,15 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
   private AppEngineRunner createStandardRunner(
       LoggingHandler loggingHandler,
       File artifactToDeploy,
-      AppEngineDeploy deploy) {
+      AppEngineDeploy deploy,
+      boolean isFlexCompat) {
     AppEngineStandardStage standardStage = new AppEngineStandardStage(
           this,
           loggingHandler,
           artifactToDeploy);
 
-    return new AppEngineRunner(new AppEngineStandardDeployTask(deploy, standardStage));
+    return new AppEngineRunner(
+        new AppEngineStandardDeployTask(deploy, standardStage, isFlexCompat));
   }
 
   private AppEngineRunner createFlexRunner(
@@ -288,12 +295,15 @@ public class CloudSdkAppEngineHelper implements AppEngineHelper {
       @Override
       public Deployment succeeded(@NotNull DeploymentRuntime deploymentRuntime) {
         UsageTrackerProvider.getInstance()
-            .trackEvent(GctTracking.CATEGORY, GctTracking.APP_ENGINE_DEPLOY, eventLabel, null);
+            .trackEvent(
+                GctTracking.CATEGORY, GctTracking.APP_ENGINE_DEPLOY_SUCCESS, eventLabel, null);
         return deploymentCallback.succeeded(deploymentRuntime);
       }
 
       @Override
       public void errorOccurred(@NotNull String errorMessage) {
+        UsageTrackerProvider.getInstance()
+            .trackEvent(GctTracking.CATEGORY, GctTracking.APP_ENGINE_DEPLOY_FAIL, eventLabel, null);
         deploymentCallback.errorOccurred(errorMessage);
       }
     };

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/util/GctTracking.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/util/GctTracking.java
@@ -25,7 +25,13 @@ public class GctTracking {
 
   // Event actions
   public static final String APP_ENGINE_DEPLOY = "appengine.deploy";
+  public static final String APP_ENGINE_DEPLOY_SUCCESS = "appengine.deploy.success";
+  public static final String APP_ENGINE_DEPLOY_FAIL = "applengine.deploy.fail";
+  public static final String APP_ENGINE_DEPLOY_CANCEL = "appengine.deploy.cancel";
+  public static final String APP_ENGINE_STOP = "appengine.stop";
+
   public static final String PROJECT_SELECTION = "project.selection";
+
   public static final String VCS_CHECKOUT = "vcs.checkout";
   public static final String VCS_UPLOAD = "vcs.uplaod";
 

--- a/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStandardDeployTaskTest.java
+++ b/google-cloud-tools-plugin/testSrc/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStandardDeployTaskTest.java
@@ -74,7 +74,7 @@ public class AppEngineStandardDeployTaskTest {
     when(deploy.getCallback()).thenReturn(callback);
     when(deploy.getDeploymentConfiguration()).thenReturn(deploymentConfiguration);
 
-    task = new AppEngineStandardDeployTask(deploy, stage);
+    task = new AppEngineStandardDeployTask(deploy, stage, false);
   }
 
   @Test


### PR DESCRIPTION
Fixes #746 to track both deploy and stop events.

I don't see a great value of the previous deploy event tracking (this was what I implemented about 3 months ago) , which is triggered only after successful deployment.

Now we track the events when at the start of each task execution. Does this sound good?