### PR TITLE
Identify and properly label all compat projects

### DIFF
--- a/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
+++ b/google-cloud-tools-plugin/resources/messages/CloudToolsBundle.properties
@@ -23,6 +23,7 @@ plugin.compatibility.error.update.link=Please {0}click here{1} to ensure that yo
 
 appengine.name=App Engine (BETA)
 appengine.environment.name.flexible=App Engine flexible
+appengine.environment.name.mvm=App Engine MVM
 appengine.environment.name.standard=App Engine standard
 appengine.tools.menu.item.label=Deploy to App Engine...
 appengine.version.label=Version\:

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -134,8 +134,10 @@ public class AppEngineDeploymentRunConfigurationEditor extends
               COST_WARNING_CLOSE_TAG));
       appEngineCostWarningLabel.addHyperlinkListener(new BrowserOpeningHyperLinkListener());
       appEngineCostWarningLabel.setBackground(editorPanel.getBackground());
+      environmentLabel.setText(getEnvironmentDisplayableLabel());
     } else {
       appEngineCostWarningLabel.setVisible(false);
+      environmentLabel.setText(environment.localizedLabel());
     }
 
     configTypeComboBox.setModel(new DefaultComboBoxModel(ConfigType.values()));
@@ -217,11 +219,6 @@ public class AppEngineDeploymentRunConfigurationEditor extends
     versionOverrideCheckBox.addItemListener(
         new CustomFieldOverrideListener(versionOverrideCheckBox, versionIdField));
 
-    if (environment.isStandard()) {
-      environmentLabel.setText(environment.localizedLabel());
-    } else {
-      environmentLabel.setText(getEnvironmentDisplayableLabel());
-    }
     appEngineFlexConfigPanel.setVisible(
         environment == AppEngineEnvironment.APP_ENGINE_FLEX
             && !AppEngineUtil.isFlexCompat(project, deploymentSource));

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -290,8 +290,8 @@ public class AppEngineDeploymentRunConfigurationEditor extends
     XmlTag compatConfig = AppEngineUtil.getFlexCompatXmlConfiguration(project, deploymentSource);
 
     if (compatConfig != null) {
-      if ("env".equals(compatConfig.getName())
-          && "flex".equals(compatConfig.getValue().getTrimmedText())) {
+      if ("env".equalsIgnoreCase(compatConfig.getName())
+          && "flex".equalsIgnoreCase(compatConfig.getValue().getTrimmedText())) {
         return GctBundle.message("appengine.environment.name.mvm");
       }
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineDeploymentRunConfigurationEditor.java
@@ -295,7 +295,7 @@ public class AppEngineDeploymentRunConfigurationEditor extends
     if (compatConfig != null) {
       if ("env".equals(compatConfig.getName())
           && "flex".equals(compatConfig.getValue().getTrimmedText())) {
-        return "MVM";
+        return GctBundle.message("appengine.environment.name.mvm");
       }
     }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
@@ -184,8 +184,7 @@ public class AppEngineUtil {
     return isFlexCompat(project, getArtifact(source));
   }
 
-  private static boolean isFlexCompat(@NotNull Project project,
-      @Nullable Artifact artifact) {
+  private static boolean isFlexCompat(@NotNull Project project, @Nullable Artifact artifact) {
     if (artifact == null) {
       return false;
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
@@ -197,10 +197,10 @@ public class AppEngineUtil {
 
     String tagName = compatConfig.getName();
 
-    if ("vm".equals(tagName)) {
+    if ("vm".equalsIgnoreCase(tagName)) {
       return Boolean.parseBoolean(compatConfig.getValue().getTrimmedText());
-    } else if ("env".equals(tagName)) {
-      return "flex".equals(compatConfig.getValue().getTrimmedText());
+    } else if ("env".equalsIgnoreCase(tagName)) {
+      return "flex".equalsIgnoreCase(compatConfig.getValue().getTrimmedText());
     } else {
       return false;
     }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/util/AppEngineUtil.java
@@ -40,6 +40,7 @@ import com.intellij.packaging.impl.artifacts.ArtifactUtil;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.xml.XmlFile;
 import com.intellij.psi.xml.XmlTag;
+import com.intellij.remoteServer.configuration.deployment.ArtifactDeploymentSource;
 import com.intellij.remoteServer.configuration.deployment.DeploymentSource;
 import com.intellij.remoteServer.configuration.deployment.ModuleDeploymentSource;
 import com.intellij.util.xml.DomFileElement;
@@ -130,30 +131,25 @@ public class AppEngineUtil {
   }
 
   /**
-   * Determines if a project is set up like an App Engine standard project but is configured
-   * in 'compatibility' mode. This indicates that the project runs in the flexible environment.
+   * Returns the xml tag corresponding to the project's appengine-web.xml compat configuration
+   * or null if there isn't one.
    */
-  public static boolean isFlexCompat(@NotNull Project project, @NotNull DeploymentSource source) {
-    Artifact artifact;
-    if (source instanceof AppEngineArtifactDeploymentSource) {
-      artifact = ((AppEngineArtifactDeploymentSource) source).getArtifact();
-      if (artifact != null) {
-        return isFlexCompat(project, artifact);
-      }
-    }
-
-    return false;
+  @Nullable
+  public static XmlTag getFlexCompatXmlConfiguration(@NotNull Project project,
+      @NotNull DeploymentSource source)  {
+    return getFlexCompatXmlConfiguration(project, getArtifact(source));
   }
 
-  private static boolean isFlexCompat(@NotNull Project project,
-      @NotNull Artifact artifact) {
-    if (!isAppEngineStandardArtifact(project, artifact)) {
-      return false;
+  @Nullable
+  private static XmlTag getFlexCompatXmlConfiguration(@NotNull Project project,
+      @Nullable Artifact artifact) {
+
+    if (artifact == null || !isAppEngineStandardArtifact(project, artifact)) {
+      return null;
     }
 
     XmlFile webXml = loadAppEngineStandardWebXml(project, artifact);
 
-    boolean isVmTrue = false;
     if (webXml != null) {
       DomManager manager = DomManager.getDomManager(project);
       DomFileElement element = manager.getFileElement(webXml);
@@ -163,13 +159,61 @@ public class AppEngineUtil {
         if (root != null) {
           XmlTag vmTag = root.findFirstSubTag("vm");
           if (vmTag != null) {
-            isVmTrue = Boolean.parseBoolean(vmTag.getValue().getTrimmedText());
+            return vmTag;
+          } else {
+            return root.findFirstSubTag("env");
           }
         }
       }
     }
 
-    return isVmTrue;
+    return null;
+  }
+
+  /**
+   * Determines if a project is set up like an App Engine standard project but is configured
+   * in 'compatibility' mode. This indicates that the project runs in the flexible environment.
+   *
+   * <p>A flex compat project has an appengine-web.xml with either:
+   * {@code
+   * <vm>true</vm>
+   * <env>flex</env>
+   * }
+   */
+  public static boolean isFlexCompat(@NotNull Project project, @NotNull DeploymentSource source) {
+    return isFlexCompat(project, getArtifact(source));
+  }
+
+  private static boolean isFlexCompat(@NotNull Project project,
+      @Nullable Artifact artifact) {
+    if (artifact == null) {
+      return false;
+    }
+
+    XmlTag compatConfig = getFlexCompatXmlConfiguration(project, artifact);
+
+    if (compatConfig == null) {
+      return false;
+    }
+
+    String tagName = compatConfig.getName();
+
+    if ("vm".equals(tagName)) {
+      return Boolean.parseBoolean(compatConfig.getValue().getTrimmedText());
+    } else if ("env".equals(tagName)) {
+      return "flex".equals(compatConfig.getValue().getTrimmedText());
+    } else {
+      return false;
+    }
+  }
+
+  @Nullable
+  private static Artifact getArtifact(@NotNull DeploymentSource source) {
+    if (source instanceof ArtifactDeploymentSource) {
+      return ((ArtifactDeploymentSource) source).getArtifact();
+    }
+
+    return null;
   }
 
   private static AppEngineArtifactDeploymentSource createArtifactDeploymentSource(


### PR DESCRIPTION
fixes #751

Project's with all applicable compat configuations in appengine-web.xml are now given the flex-compat treatement. The only difference is the labeling in the UI:

![image](https://cloud.githubusercontent.com/assets/1735744/16280358/1f2ed908-388d-11e6-89d9-7f57dc5d4308.png)
