### PR TITLE
Service lookup should use interface

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.intellij.stats;
 
+import com.google.cloud.tools.intellij.AccountPluginInfoService;
 import com.google.cloud.tools.intellij.IdeaAccountPluginInfoService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -51,9 +52,12 @@ public class GoogleUsageTracker implements UsageTracker {
   private static final String ANALYTICS_URL = "https://ssl.google-analytics.com/collect";
 
   private final String analyticsId;
+  private String externalPluginName;
 
   public GoogleUsageTracker() {
-    this.analyticsId = UsageTrackerManager.getInstance().getAnalyticsProperty();
+    analyticsId = UsageTrackerManager.getInstance().getAnalyticsProperty();
+    externalPluginName = ServiceManager.getService(AccountPluginInfoService.class)
+        .getExternalPluginName();
   }
 
   private static final List<BasicNameValuePair> analyticsBaseData = ImmutableList
@@ -80,9 +84,6 @@ public class GoogleUsageTracker implements UsageTracker {
 
         List<BasicNameValuePair> postData = Lists.newArrayList(analyticsBaseData);
         postData.add(new BasicNameValuePair("tid", analyticsId));
-
-        String externalPluginName =
-            ServiceManager.getService(IdeaAccountPluginInfoService.class).getExternalPluginName();
         postData.add(new BasicNameValuePair("cd19", externalPluginName));  // Event type
         postData.add(new BasicNameValuePair("cd20", eventAction));  // Event name
         postData.add(new BasicNameValuePair("cd16", "0"));  // Internal user? No.

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -53,6 +53,10 @@ public class GoogleUsageTracker implements UsageTracker {
   private final String analyticsId;
   private String externalPluginName;
 
+  /**
+   * Constructs a usage tracker configured with analytics and plugin name configured from its
+   * environment.
+   */
   public GoogleUsageTracker() {
     analyticsId = UsageTrackerManager.getInstance().getAnalyticsProperty();
     externalPluginName = ServiceManager.getService(AccountPluginInfoService.class)

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.intellij.stats;
 
 import com.google.cloud.tools.intellij.AccountPluginInfoService;
-import com.google.cloud.tools.intellij.IdeaAccountPluginInfoService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 


### PR DESCRIPTION
The ServiceManager basically maps interface types to implementations
based off of the plugin.xml.  Make sure to retrieve the implementations
using the interface type and not the implementation type.

I'm also moving the initialization to the constructor since the client
type should never change at runtime.