### PR TITLE
IJ build version

### DIFF
--- a/google-account-plugin/resources/META-INF/plugin.xml
+++ b/google-account-plugin/resources/META-INF/plugin.xml
@@ -20,7 +20,7 @@
   <!-- "version" set by gradle-intellij-plugin -->
   <!-- "idea-version since-build" set by gradle-intellij-plugin -->
   <!-- Workaround for gradle-intellij-plugin limitation: https://github.com/JetBrains/gradle-intellij-plugin/issues/66 -->
-  <!-- Setting version to 15.0.6 and up. https://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+15+143.1821.5+Release+Notes -->
+  <!-- Setting version to 15.0.6 and up. https://confluence.jetbrains.com/display/IDEADEV/IDEA+15+EAP -->
   <idea-version since-build="143.2370.31" />
 
   <description>

--- a/google-account-plugin/resources/META-INF/plugin.xml
+++ b/google-account-plugin/resources/META-INF/plugin.xml
@@ -20,8 +20,8 @@
   <!-- "version" set by gradle-intellij-plugin -->
   <!-- "idea-version since-build" set by gradle-intellij-plugin -->
   <!-- Workaround for gradle-intellij-plugin limitation: https://github.com/JetBrains/gradle-intellij-plugin/issues/66 -->
-  <!-- Setting version to 15.0.3 and up. https://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+15+143.1821.5+Release+Notes -->
-  <idea-version since-build="143.1821.5" />
+  <!-- Setting version to 15.0.6 and up. https://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+15+143.1821.5+Release+Notes -->
+  <idea-version since-build="143.2370.31" />
 
   <description>
     Provides Google account setting and authentication for IntelliJ plugins that need it.

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -23,8 +23,8 @@ Code inspections for App Engine Java code.</description>
   <!-- "version" set by gradle-intellij-plugin -->
   <!-- "idea-version since-build" set by gradle-intellij-plugin -->
   <!-- Workaround for gradle-intellij-plugin limitation: https://github.com/JetBrains/gradle-intellij-plugin/issues/66 -->
-  <!-- Setting version to 15.0.3 and up. https://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+15+143.1821.5+Release+Notes -->
-  <idea-version since-build="143.1821.5" />
+  <!-- Setting version to 15.0.6 and up. https://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+15+143.1821.5+Release+Notes -->
+  <idea-version since-build="143.2370.31" />
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>

--- a/google-cloud-tools-plugin/resources/META-INF/plugin.xml
+++ b/google-cloud-tools-plugin/resources/META-INF/plugin.xml
@@ -23,7 +23,7 @@ Code inspections for App Engine Java code.</description>
   <!-- "version" set by gradle-intellij-plugin -->
   <!-- "idea-version since-build" set by gradle-intellij-plugin -->
   <!-- Workaround for gradle-intellij-plugin limitation: https://github.com/JetBrains/gradle-intellij-plugin/issues/66 -->
-  <!-- Setting version to 15.0.6 and up. https://confluence.jetbrains.com/display/IDEADEV/IntelliJ+IDEA+15+143.1821.5+Release+Notes -->
+  <!-- Setting version to 15.0.6 and up. https://confluence.jetbrains.com/display/IDEADEV/IDEA+15+EAP -->
   <idea-version since-build="143.2370.31" />
 
   <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
I noticed we were still targeting 15.0.3 in our plugin configuration (this determines which version of the IDE the plugin supports from the plugin repository). 

This updates it to 15.0.6.

@patflynn 