### PR TITLE
Check for null environment even if the artifact is present

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSourceType.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineArtifactDeploymentSourceType.java
@@ -67,10 +67,10 @@ public class AppEngineArtifactDeploymentSourceType
           }
       );
 
-      if (artifact.isPresent()) {
-        String environment = settings.getAttributeValue(
-            AppEngineDeploymentConfiguration.ENVIRONMENT_ATTRIBUTE);
+      String environment = settings.getAttributeValue(
+          AppEngineDeploymentConfiguration.ENVIRONMENT_ATTRIBUTE);
 
+      if (artifact.isPresent() && environment != null) {
         return new AppEngineArtifactDeploymentSource(
             AppEngineEnvironment.valueOf(environment),
             ArtifactPointerManager.getInstance(project).createPointer(artifact.get()));


### PR DESCRIPTION
fixes #770 

@chanseokoh ptal.

I am still debugging the ultimate root cause of this of how this happened in the first place (so far I am only able to reproduce it in IJ UE RC 2016.2) but this fix will prevent the NPE which was caused by doing a `valueOf` on an enum with a null parameter.