### PR TITLE
Suppress missing javadoc warning

### DIFF
--- a/google_checks.xml
+++ b/google_checks.xml
@@ -205,6 +205,7 @@
         </module>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
+            <property name="allowMissingJavadoc" value="true"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>


### PR DESCRIPTION
For some things like constructors that are well named and don't do much, its a little annoying to be forced to have to write a javadoc. I think its better to have no comment than a redundant one.

This suppresses this checkstyle check.

@aslo please take a look