### PR TITLE
Suppress checkstyle javadoc trailing period check

### DIFF
--- a/google_checks.xml
+++ b/google_checks.xml
@@ -197,6 +197,7 @@
         <module name="JavadocTagContinuationIndentation"/>
         <module name="SummaryJavadoc">
             <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+            <property name="period" value=""/>
         </module>
         <module name="JavadocParagraph"/>
         <module name="AtclauseOrder">


### PR DESCRIPTION
Removing the checkstyle check that forces you to have a period at the end of the first sentence of a javadoc. Usually this is ok, but for things like the following it just gets in the way:

```
/**
 * @author user
 */

```

@aslo  ptal