### PR TITLE
Initialize the login widget from the credential datastore at startup

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/AccountPluginInitializationComponent.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/AccountPluginInitializationComponent.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.intellij;
 
+import com.google.cloud.tools.intellij.login.Services;
 import com.google.cloud.tools.intellij.login.util.TrackerMessageBundle;
 import com.google.cloud.tools.intellij.stats.UsageTrackerManager;
 import com.google.cloud.tools.intellij.stats.UsageTrackerNotification;
@@ -54,6 +55,7 @@ public class AccountPluginInitializationComponent implements ApplicationComponen
     if (!ApplicationManager.getApplication().isUnitTestMode()) {
       configureUsageTracking();
     }
+    Services.getLoginService().loadPersistedCredentials();
   }
 
   @Override

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/GoogleLoginService.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/GoogleLoginService.java
@@ -127,4 +127,9 @@ public interface GoogleLoginService {
    * @param button The login menu item.
    */
   void setLoginMenuItemContribution(GoogleLoginActionButton button);
+
+  /**
+   * Initializes the service from the persisted credential store.
+   */
+  void loadPersistedCredentials();
 }

--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/IntellijGoogleLoginService.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/IntellijGoogleLoginService.java
@@ -303,6 +303,11 @@ public class IntellijGoogleLoginService implements GoogleLoginService {
     uiFacade.setLoginMenuItemContribution(button);
   }
 
+  @Override
+  public void loadPersistedCredentials() {
+    dataStore.initializeUsers();
+  }
+
   /**
    * Logs out all signed in users without popping up logout confirmation message.
    */

--- a/google-account-plugin/testSrc/com/google/cloud/tools/intellij/AccountPluginInitializationComponentTest.java
+++ b/google-account-plugin/testSrc/com/google/cloud/tools/intellij/AccountPluginInitializationComponentTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.tools.intellij.login.GoogleLoginService;
 import com.google.cloud.tools.intellij.testing.BasePluginTestCase;
 
 import com.intellij.openapi.Disposable;
@@ -47,6 +48,9 @@ public class AccountPluginInitializationComponentTest extends BasePluginTestCase
   AccountPluginInfoService pluginInfoService;
   @Mock
   AccountPluginConfigurationService pluginConfigurationService;
+  @Mock
+  GoogleLoginService googleLoginService;
+
   AccountPluginInitializationComponent testComponent;
 
 
@@ -54,6 +58,7 @@ public class AccountPluginInitializationComponentTest extends BasePluginTestCase
   public void registerMockServices() {
     registerService(AccountPluginInfoService.class, pluginInfoService);
     registerService(AccountPluginConfigurationService.class, pluginConfigurationService);
+    registerService(GoogleLoginService.class, googleLoginService);
     testComponent = new AccountPluginInitializationComponent();
   }
 
@@ -92,5 +97,11 @@ public class AccountPluginInitializationComponentTest extends BasePluginTestCase
     AccountPluginInitializationComponent testComponent = spy(new AccountPluginInitializationComponent());
     testComponent.initComponent();
     verify(testComponent, never()).configureUsageTracking();
+  }
+
+  @Test
+  public void testInitComponent_loginServiceIsInitialized() {
+    testComponent.initComponent();
+    verify(googleLoginService).loadPersistedCredentials();
   }
 }


### PR DESCRIPTION
Fixes #794.

Really the service should initialize itself.  I haven't implemented it
that way because of some pretty gnarly circular dependencies in the
initialization.

Basically the service calls itself through delegates during
initialization. In addition multiple instances of the datastore are
actually instantiated during intitialization.