### PR TITLE
Update the ideaVersion for our 2016.2 builds on travis to 2016.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   - jdk: openjdk7
     env: ORG_GRADLE_PROJECT_ideaVersion=15.0.6
   - jdk: oraclejdk8
-    env: ORG_GRADLE_PROJECT_ideaVersion=162.1447.21 # latest 2016.2 build
+    env: ORG_GRADLE_PROJECT_ideaVersion=2016.2.1
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:


### PR DESCRIPTION
Updates our build matrix on travis-ci to use a more-appropriate major release.

We are able to make this change because the `2016.2.1` release contains backported changes that enable backward-compatibility with older IDEA versions.