### PR TITLE
Set user-agent to "Automated" for Analytics event pings

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/stats/GoogleUsageTracker.java
@@ -114,7 +114,7 @@ public class GoogleUsageTracker implements UsageTracker, SendsEvents {
   private static void sendPing(@NotNull final List<? extends NameValuePair> postData) {
     ApplicationManager.getApplication().executeOnPooledThread(new Runnable() {
       public void run() {
-        CloseableHttpClient client = HttpClientBuilder.create().build();
+        CloseableHttpClient client = HttpClientBuilder.create().setUserAgent("Automated").build();
         HttpPost request = new HttpPost(ANALYTICS_URL);
 
         try {


### PR DESCRIPTION
Previously, it was `"Apache-HttpClient/4.4.1 (Java/1.7.0_101)"`. Setting it to `"Automated"` prevents GA from filtering out our pings.

`"Automated"`actually comes from [here](https://github.com/google/cloud-reporting/blob/master/src/main/java/com/google/cloud/metrics/MetricsUtils.java#L78).