### PR TITLE
reset idea version to 15.0.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 ideaEdition = IC
-ideaVersion = 2016.2.1
+ideaVersion = 15.0.6
 javaVersion = 1.7
 ijPluginRepoChannel = alpha
 version = 0.9.8-beta-SNAPSHOT


### PR DESCRIPTION
A previous PR accidentally changed this version. We still want this set to our earliest supported build.