### PR TITLE
Removing analytics oauth scopes

### DIFF
--- a/google-account-plugin/src/com/google/cloud/tools/intellij/login/OAuthScopeRegistry.java
+++ b/google-account-plugin/src/com/google/cloud/tools/intellij/login/OAuthScopeRegistry.java
@@ -34,9 +34,6 @@ class OAuthScopeRegistry {
     scopes.add("https://www.googleapis.com/auth/appengine.admin");
     scopes.add("https://www.googleapis.com/auth/cloud-platform");
     scopes.add("https://www.googleapis.com/auth/projecthosting");
-    scopes.add("https://www.googleapis.com/auth/analytics");
-    scopes.add("https://www.googleapis.com/auth/analytics.edit");
-    scopes.add("https://www.googleapis.com/auth/analytics.readonly");
     scopes.add("https://www.googleapis.com/auth/cloud_debugger");
     SCOPES = Collections.unmodifiableSortedSet(scopes);
   }


### PR DESCRIPTION
They are not used by our plugins in intellij.