### PR TITLE
Only send undeploy analytics ping for actual deployment cancellations.

### DIFF
--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineFlexibleDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineFlexibleDeployTask.java
@@ -85,6 +85,9 @@ public class AppEngineFlexibleDeployTask extends AppEngineTask {
 
   @Override
   void onCancel() {
-    UsageTrackerProvider.getInstance().trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL).ping();
+    UsageTrackerProvider.getInstance()
+        .trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL)
+        .withLabel("flex")
+        .ping();
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineFlexibleDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineFlexibleDeployTask.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Runnable that executes a task responsible for deploying an application to the App Engine
  * flexible environment.
  */
-public class AppEngineFlexibleDeployTask implements AppEngineTask {
+public class AppEngineFlexibleDeployTask extends AppEngineTask {
   private static final Logger logger = Logger.getInstance(AppEngineFlexibleDeployTask.class);
 
   private AppEngineDeploy deploy;
@@ -81,5 +81,10 @@ public class AppEngineFlexibleDeployTask implements AppEngineTask {
           + GctBundle.message("appengine.action.error.update.message"));
       logger.error(re);
     }
+  }
+
+  @Override
+  void onCancel() {
+    UsageTrackerProvider.getInstance().trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL).ping();
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineRunner.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineRunner.java
@@ -17,8 +17,6 @@
 package com.google.cloud.tools.intellij.appengine.cloud;
 
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
-import com.google.cloud.tools.intellij.stats.UsageTrackerProvider;
-import com.google.cloud.tools.intellij.util.GctTracking;
 
 import com.intellij.openapi.vcs.impl.CancellableRunnable;
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineRunner.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineRunner.java
@@ -46,10 +46,9 @@ public class AppEngineRunner implements CancellableRunnable {
 
   @Override
   public void cancel() {
-    UsageTrackerProvider.getInstance().trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL).ping();
-
     if (process != null) {
       process.destroy();
+      task.onCancel();
     }
   }
 

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStandardDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStandardDeployTask.java
@@ -34,7 +34,7 @@ import java.io.IOException;
  * Runnable that executes task responsible for deploying an application to the App Engine standard
  * environment.
  */
-public class AppEngineStandardDeployTask implements AppEngineTask {
+public class AppEngineStandardDeployTask extends AppEngineTask {
 
   private static final Logger logger = Logger.getInstance(AppEngineStandardDeployTask.class);
 
@@ -114,5 +114,10 @@ public class AppEngineStandardDeployTask implements AppEngineTask {
         }
       }
     };
+  }
+
+  @Override
+  void onCancel() {
+    UsageTrackerProvider.getInstance().trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL).ping();
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStandardDeployTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStandardDeployTask.java
@@ -118,6 +118,9 @@ public class AppEngineStandardDeployTask extends AppEngineTask {
 
   @Override
   void onCancel() {
-    UsageTrackerProvider.getInstance().trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL).ping();
+    UsageTrackerProvider.getInstance()
+        .trackEvent(GctTracking.APP_ENGINE_DEPLOY_CANCEL)
+        .withLabel(isFlexCompat ? "flex-compat" : "standard")
+        .ping();
   }
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStopTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineStopTask.java
@@ -26,7 +26,7 @@ import com.intellij.openapi.diagnostic.Logger;
 /**
  * Runnable that executes task responsible for stopping an App Engine application.
  */
-public class AppEngineStopTask implements AppEngineTask {
+public class AppEngineStopTask extends AppEngineTask {
   private static final Logger logger = Logger.getInstance(AppEngineStopTask.class);
 
   private AppEngineStop stop;

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineTask.java
@@ -21,12 +21,18 @@ import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
 /**
  * Encapsulates a task to be run on Google App Engine.
  */
-public interface AppEngineTask {
+public abstract class AppEngineTask {
 
   /**
    * Executes an App Engine task.
    * @param startListener a callback for retrieving the running process
    */
-  void execute(ProcessStartListener startListener);
+  abstract void execute(ProcessStartListener startListener);
+
+  /**
+   * Gets invoked with the task gets cancelled by {@link AppEngineRunner}
+   */
+  void onCancel() {
+  }
 
 }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineTask.java
@@ -30,7 +30,7 @@ public abstract class AppEngineTask {
   abstract void execute(ProcessStartListener startListener);
 
   /**
-   * Gets invoked with the task gets cancelled by {@link AppEngineRunner}
+   * Gets invoked when the task gets cancelled by {@link AppEngineRunner}
    */
   void onCancel() {
   }

--- a/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineTask.java
+++ b/google-cloud-tools-plugin/src/com/google/cloud/tools/intellij/appengine/cloud/AppEngineTask.java
@@ -30,7 +30,9 @@ public abstract class AppEngineTask {
   abstract void execute(ProcessStartListener startListener);
 
   /**
-   * Gets invoked when the task gets cancelled by {@link AppEngineRunner}
+   * Gets invoked when the task gets cancelled by {@link AppEngineRunner}.
+   * Intentionally left empty - it is up to implementors to decide if they need extra
+   * action on cancellation.
    */
   void onCancel() {
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ideaEdition = IU
+ideaEdition = IC
 ideaVersion = 15.0.6
 javaVersion = 1.7
 ijPluginRepoChannel = alpha

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ideaEdition = IC
+ideaEdition = IU
 ideaVersion = 15.0.6
 javaVersion = 1.7
 ijPluginRepoChannel = alpha


### PR DESCRIPTION
fixes #831 

@patflynn what do you think of this approach?

To be determined: do we want a separate type of ping for flex vs standard deploy cancellations. Also, now that I'm thinking about it, do we really care about tracking cancellations (note this is completely different than undeployments).