### PR TITLE
Temporarily disable parallel environment builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: java
-matrix:
-  include:
-  - jdk: openjdk7
-    env: ORG_GRADLE_PROJECT_ideaVersion=15.0.6
-  - jdk: oraclejdk8
-    env: ORG_GRADLE_PROJECT_ideaVersion=2016.2.1
+jdk:
+  - openjdk7
+#matrix:
+#  include:
+#  - jdk: openjdk7
+#    env: ORG_GRADLE_PROJECT_ideaVersion=15.0.6
+#  - jdk: oraclejdk8
+#    env: ORG_GRADLE_PROJECT_ideaVersion=2016.2.1
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 #
 
 ideaEdition = IC
-ideaVersion = 15.0.6
+ideaVersion = 2016.2.1
 javaVersion = 1.7
 ijPluginRepoChannel = alpha
 version = 0.9.8-beta-SNAPSHOT


### PR DESCRIPTION
We can't seem to get green builds with this configuration.